### PR TITLE
Can use 1st person in spec

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -11123,18 +11123,11 @@ void CG_Player( centity_t *cent ) {
 		else if (ci->team == TEAM_SPECTATOR || (cg.snap && (cg.snap->ps.pm_flags & PMF_FOLLOW)))
 		{ //don't allow this when spectating
 			if (cgFPLSState != 0)
-			{
-				trap->Cvar_Set("cg_fpls", "0");
-				cg_fpls.integer = 0;
+			{	cg_fpls.integer = 0;
 
 				CG_ForceFPLSPlayerModel(cent, ci);
 				cgFPLSState = 0;
 				return;
-			}
-
-			if (cg_fpls.integer)
-			{
-				trap->Cvar_Set("cg_fpls", "0");
 			}
 		}
 		else


### PR DESCRIPTION
Removed cvar_set cg_fpls to 0 when first person is used in spec, so now you can use first person from spec.