### PR TITLE
Added: cg_saberhum, teleport from relativ position(teleoffset), cg_dr…

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -11693,6 +11693,9 @@ static void CG_PlayerLabels(void)
 			continue;
 		if (cgs.clientinfo[i].team == TEAM_SPECTATOR)
 			continue;
+		if (cent->currentState.bolt1) // Stops drawing playernames if they are in duel - bolt1 holds duelinprogress 
+			continue;
+
 		if (CG_IsMindTricked(cent->currentState.trickedentindex,
 			cent->currentState.trickedentindex2,
 			cent->currentState.trickedentindex3,

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -2149,9 +2149,33 @@ void CG_NewClientInfo( int clientNum, qboolean entitiesInitialized ) {
 		newInfo.ghoul2Weapons[0] = ci->ghoul2Weapons[0];
 	}
 
-	if (newInfo.saber[0].soundLoop == trap->S_RegisterSound("sound/weapons/saber/saberhum4.wav")) {//probably a base hilt
-		newInfo.saber[0].soundLoop = cgs.media.saberHumSounds[clientNum % 5]; //JAPRO - Clientside - Use all saber hum sounds found in base assets
+	if (newInfo.saber[0].soundLoop == trap->S_RegisterSound("sound/weapons/saber/saberhum4.wav")) {//probably a base hilt - Have to reconnect after changing - how2fix?
+		if (cg_saberHum.integer == 0)
+		{
+			newInfo.saber[0].soundLoop = cgs.media.saberHumSounds[clientNum % 5]; //JAPRO - Clientside - Use all saber hum sounds found in base assets
+		}
+		if (cg_saberHum.integer == 1)
+		{
+			newInfo.saber[0].soundLoop = trap->S_RegisterSound("sound/weapons/saber/saberhum1.wav");
+		}
+		if (cg_saberHum.integer == 2)
+		{
+			newInfo.saber[0].soundLoop = trap->S_RegisterSound("sound/weapons/saber/saberhum2.wav");
+		}
+		if (cg_saberHum.integer == 3)
+		{
+			newInfo.saber[0].soundLoop = trap->S_RegisterSound("sound/weapons/saber/saberhum3.wav");
+		}
+		if (cg_saberHum.integer == 4)
+		{
+			newInfo.saber[0].soundLoop = trap->S_RegisterSound("sound/weapons/saber/saberhum4.wav");
+		}
+		if (cg_saberHum.integer == 5)
+		{
+			newInfo.saber[0].soundLoop = trap->S_RegisterSound("sound/weapons/saber/saberhum5.wav");
+		}
 	}
+
 
 	v = Info_ValueForKey( configstring, "st2" );
 

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -109,6 +109,7 @@ XCVAR_DEF( cg_hitsounds,						"0",	NULL,								CVAR_ARCHIVE )
 XCVAR_DEF( cg_raceSounds,						"1",	NULL,								CVAR_ARCHIVE ) //Bitvalue, but so far we just have RS_TIMER_START set up
 XCVAR_DEF( cg_duelSounds,						"1",	NULL,								CVAR_ARCHIVE )
 XCVAR_DEF( cg_duelMusic,						"1",	NULL,								CVAR_ARCHIVE )
+XCVAR_DEF( cg_saberHum,							"0",	NULL,								CVAR_ARCHIVE )
 
 //Visuals
 XCVAR_DEF( cg_remaps,							"1",	NULL,								CVAR_ARCHIVE|CVAR_LATCH )

--- a/codemp/game/g_active.c
+++ b/codemp/game/g_active.c
@@ -4835,13 +4835,13 @@ void ClientThink_real( gentity_t *ent ) {
 	//rww - bgghoul2
 	pmove.ghoul2 = NULL;
 
-#ifdef _DEBUG
+/*#ifdef _DEBUG
 	if (g_disableServerG2.integer)
 	{
 
 	}
 	else
-#endif
+#endif*/
 	if (ent->ghoul2)
 	{
 		if (ent->localAnimIndex > 1)

--- a/codemp/ui/ui_xdocs.h
+++ b/codemp/ui/ui_xdocs.h
@@ -243,6 +243,15 @@ XDOCS_CVAR_DEF("cg_rollSounds", "Play sound when players roll",
 	SETTING("3", "Only play roll sounds from local client")
 )
 
+XDOCS_CVAR_DEF("cg_saberHum", "Customize saber hum sound",
+SETTING("0", "Rotate trough all 5 sounds") NL
+SETTING("1", "Use only soundfile 1") NL
+SETTING("2", "Use only soundfile 2") NL
+SETTING("3", "Use only soundfile 3") NL
+SETTING("4", "Use only soundfile 4") NL
+SETTING("5", "Use only soundfile 5")
+)
+
 XDOCS_CVAR_DEF("cg_jumpSounds", "Play sound when players jump",
 	SETTING("0", "Don't play jump sounds") NL
 	SETTING("1", "Play all jump sounds") NL


### PR DESCRIPTION
…awplayernames 1 doesnt draw name anymore if player are in duels.

changing the cg_saberhum cvar requires a reconnect to get active.  Idk how i could do it so changing doesnt require a reconnect.

teleoffset lets u teleport from your current position x units into the x y or z axis. It also takes as 4th argument gun or a player name. This teleports you by the offsets u setted of either the crosshair target(gun) or playername.

cg_drawplayernames 1 will not stop drawing the players name above their character if they are in duel.