### PR TITLE
Option to select team force powers via menu

### DIFF
--- a/assets/japro/strings/English/EXT.str
+++ b/assets/japro/strings/English/EXT.str
@@ -1,0 +1,11 @@
+VERSION			"1"
+CONFIG			"W:\bin\stringed.cfg"
+FILENOTES		""
+
+REFERENCE           SHOW_ALL
+LANG_ENGLISH        "Show all:"
+
+REFERENCE           TOGGLE_SETTING_ALL_FORCES
+LANG_ENGLISH        "Toggle whether only currently available or all forces can be set.
+
+ENDMARKER

--- a/assets/japro/strings/English/EXT.str
+++ b/assets/japro/strings/English/EXT.str
@@ -3,7 +3,7 @@ CONFIG			"W:\bin\stringed.cfg"
 FILENOTES		""
 
 REFERENCE           SHOW_ALL
-LANG_ENGLISH        "Show all:"
+LANG_ENGLISH        "Free select:"
 
 REFERENCE           TOGGLE_SETTING_ALL_FORCES
 LANG_ENGLISH        "Toggle whether only currently available or all forces can be set.

--- a/assets/japro/ui/jamp/ingame_playerforce.menu
+++ b/assets/japro/ui/jamp/ingame_playerforce.menu
@@ -165,6 +165,34 @@
 			decoration
 		}
 
+		
+		// Toggle Show All Powers
+		itemDef 
+		{
+			name				showallpowers
+			group				"playersettingforcegroup"
+			style				0	
+			text				@EXT_SHOW_ALL
+			ownerdraw			UI_SHOW_ALL_FORCES
+			rect				338 50 60 35
+			textalign			ITEM_ALIGN_CENTER
+			textalignx			30
+			textaligny			17
+			outlinecolor			1 .5 .5 .5
+			backcolor			0 0 0 0
+			font				2
+			textscale			.5
+			forecolor			1 .682 0 .8
+			border				0
+			bordercolor			0 0 0 0
+			descText			@EXT_TOGGLE_SETTING_ALL_FORCES
+			visible				1 
+			action 
+			{ 
+				play			"sound/interface/button1.wav" ;  
+			}
+		}
+
 
 
 		//----------------------------------------
@@ -904,14 +932,10 @@
 			bordercolor				0 0 0 0
 			visible					1 
 			decoration
-			cvarTest				"ui_about_gametype"
+			cvarTest				"ui_drawTeamForces"
 			hideCvar 
 			{ 
-				"0" ; 
-				"1" ; 
-				"2" ; 
-				"3" ;
-				"4"
+				"0"
 			}
 		}
 
@@ -934,14 +958,10 @@
 			bordercolor				0 0 0 0
 			descText				@MENUS_CHANNEL_THE_FORCE_TO
 			visible					1 
-			cvarTest				"ui_about_gametype"
+			cvarTest				"ui_drawTeamForces"
 			hideCvar 
 			{ 
-				"0" ; 
-				"1" ; 
-				"2" ; 
-				"3" ;
-				"4"
+				"0"
 			}
 			action 
 			{ 
@@ -1210,14 +1230,10 @@
 			bordercolor				0 0 0 0
 			visible					1 
 			decoration
-			cvarTest				"ui_about_gametype"
+			cvarTest				"ui_drawTeamForces"
 			hideCvar 
 			{ 
-				"0" ; 
-				"1" ; 
-				"2" ; 
-				"3" ;
-				"4"
+				"0"
 			}
 		}
 
@@ -1240,14 +1256,10 @@
 			bordercolor				0 0 0 0
 			descText				@MENUS_THE_FORCE_TO_BOOST_THE
 			visible					1 
-			cvarTest				"ui_about_gametype"
+			cvarTest				"ui_drawTeamForces"
 			hideCvar 
 			{ 
-				"0" ; 
-				"1" ; 
-				"2" ; 
-				"3" ;
-				"4"
+				"0"
 			}
 			action 
 			{ 

--- a/assets/japro/ui/jamp/ingame_playerforce.menu
+++ b/assets/japro/ui/jamp/ingame_playerforce.menu
@@ -174,14 +174,14 @@
 			style				0	
 			text				@EXT_SHOW_ALL
 			ownerdraw			UI_SHOW_ALL_FORCES
-			rect				338 50 60 35
+			rect				325 335 80 25
 			textalign			ITEM_ALIGN_CENTER
-			textalignx			30
-			textaligny			17
+			textalignx			40
+			textaligny			5
 			outlinecolor			1 .5 .5 .5
 			backcolor			0 0 0 0
 			font				2
-			textscale			.5
+			textscale			.8
 			forecolor			1 .682 0 .8
 			border				0
 			bordercolor			0 0 0 0

--- a/assets/japro/ui/jamp/menudef.h
+++ b/assets/japro/ui/jamp/menudef.h
@@ -396,6 +396,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define UI_VGS_TEAM			323
 #define UI_VGS_MEME			324
 
+// It would be handy
+#define UI_SHOW_ALL_FORCES  325
+
 #define VOICECHAT_GETFLAG			"getflag"				// command someone to get the flag
 #define VOICECHAT_OFFENSE			"offense"				// command someone to go on offense
 #define VOICECHAT_DEFEND			"defend"				// command someone to go on defense

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -309,7 +309,6 @@ void CG_ParseServerinfo( void ) {
 #endif
 	
 	trap->Cvar_Set ( "ui_about_gametype", va("%i", cgs.gametype ) );
-	trap->Cvar_Set ( "ui_drawTeamForces", va("%i", Q_stricmp(Info_ValueForKey(info, "cg_enableForceMenu"), "0") || cgs.gametype >= GT_TEAM));
 	trap->Cvar_Set ( "ui_about_fraglimit", va("%i", cgs.fraglimit ) );
 	trap->Cvar_Set ( "ui_about_duellimit", va("%i", cgs.duel_fraglimit ) );
 	trap->Cvar_Set ( "ui_about_capturelimit", va("%i", cgs.capturelimit ) );

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -307,9 +307,9 @@ void CG_ParseServerinfo( void ) {
 #else
 	Q_strncpyz( cgs.rawmapname, mapname, sizeof( cgs.rawmapname ) );
 #endif
-
+	
 	trap->Cvar_Set ( "ui_about_gametype", va("%i", cgs.gametype ) );
-	trap->Cvar_Set ( "ui_drawTeamForces", va("%i", Info_ValueForKey(info, "cg_enableForceMenu") || ((int)cgs.gametype > 4)));
+	trap->Cvar_Set ( "ui_drawTeamForces", va("%i", Q_stricmp(Info_ValueForKey(info, "cg_enableForceMenu"), "0") || cgs.gametype >= GT_TEAM));
 	trap->Cvar_Set ( "ui_about_fraglimit", va("%i", cgs.fraglimit ) );
 	trap->Cvar_Set ( "ui_about_duellimit", va("%i", cgs.duel_fraglimit ) );
 	trap->Cvar_Set ( "ui_about_capturelimit", va("%i", cgs.capturelimit ) );

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -309,6 +309,7 @@ void CG_ParseServerinfo( void ) {
 #endif
 
 	trap->Cvar_Set ( "ui_about_gametype", va("%i", cgs.gametype ) );
+	trap->Cvar_Set ( "ui_drawTeamForces", va("%i", Info_ValueForKey(info, "cg_enableForceMenu") || ((int)cgs.gametype > 4)));
 	trap->Cvar_Set ( "ui_about_fraglimit", va("%i", cgs.fraglimit ) );
 	trap->Cvar_Set ( "ui_about_duellimit", va("%i", cgs.duel_fraglimit ) );
 	trap->Cvar_Set ( "ui_about_capturelimit", va("%i", cgs.capturelimit ) );

--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -644,8 +644,8 @@ qboolean BG_LegalizedForcePowers2(char* powerOut, size_t powerOutSize, int maxRa
 		{
 			final_Powers[FP_TEAM_FORCE] = 0;
 		}
-		if ((final_Side == FORCE_LIGHTSIDE) ||
-			(final_Side == FORCE_DARKSIDE && (fpDisabled & (1 << FP_TEAM_HEAL))))
+		if ((final_Side == FORCE_DARKSIDE) ||
+			(final_Side == FORCE_LIGHTSIDE && (fpDisabled & (1 << FP_TEAM_HEAL))))
 		{
 			final_Powers[FP_TEAM_HEAL] = 0;
 		}

--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -637,10 +637,18 @@ qboolean BG_LegalizedForcePowers2(char* powerOut, size_t powerOutSize, int maxRa
 		i++;
 	}
 
-	if (gametype < GT_TEAM && !forceTeamForces)
-	{ //don't bother with team powers then
-		final_Powers[FP_TEAM_HEAL] = 0;
-		final_Powers[FP_TEAM_FORCE] = 0;
+	if (!forceTeamForces && gametype < GT_TEAM)
+	{
+		if ((final_Side == FORCE_LIGHTSIDE) ||
+			(final_Side == FORCE_DARKSIDE && (fpDisabled & (1 << FP_TEAM_FORCE))))
+		{
+			final_Powers[FP_TEAM_FORCE] = 0;
+		}
+		if ((final_Side == FORCE_LIGHTSIDE) ||
+			(final_Side == FORCE_DARKSIDE && (fpDisabled & (1 << FP_TEAM_HEAL))))
+		{
+			final_Powers[FP_TEAM_HEAL] = 0;
+		}
 	}
 
 	usedPoints = 0;

--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -528,7 +528,11 @@ fpDisabled is actually only expected (needed) from the server, because the ui di
 force power selection anyway when force powers are disabled on the server.
 ================
 */
-qboolean BG_LegalizedForcePowers(char *powerOut, size_t powerOutSize, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled)
+qboolean BG_LegalizedForcePowers(char* powerOut, size_t powerOutSize, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled)
+{
+	return BG_LegalizedForcePowers2(powerOut, powerOutSize, maxRank, freeSaber, teamForce, gametype, fpDisabled, qfalse);
+}
+qboolean BG_LegalizedForcePowers2(char* powerOut, size_t powerOutSize, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled, qboolean forceTeamForces)
 {
 	char powerBuf[128];
 	char readBuf[128];
@@ -633,7 +637,7 @@ qboolean BG_LegalizedForcePowers(char *powerOut, size_t powerOutSize, int maxRan
 		i++;
 	}
 
-	if (gametype < GT_TEAM)
+	if (gametype < GT_TEAM && !forceTeamForces)
 	{ //don't bother with team powers then
 		final_Powers[FP_TEAM_HEAL] = 0;
 		final_Powers[FP_TEAM_FORCE] = 0;

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -1810,7 +1810,7 @@ typedef struct saberInfo_s {
 bgEntity_t *PM_BGEntForNum( int num );
 qboolean BG_KnockDownable(playerState_t *ps);
 qboolean BG_LegalizedForcePowers(char *powerOut, size_t powerOutSize, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled);
-
+qboolean BG_LegalizedForcePowers2(char* powerOut, size_t powerOutSize, int maxRank, qboolean freeSaber, int teamForce, int gametype, int fpDisabled, qboolean forceTeamForces);
 
 // given a boltmatrix, return in vec a normalised vector for the axis requested in flags
 void BG_GiveMeVectorFromMatrix(mdxaBone_t *boltMatrix, int flags, vec3_t vec);

--- a/codemp/ui/menudef.h
+++ b/codemp/ui/menudef.h
@@ -398,6 +398,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define UI_VGS_TEAM			323
 #define UI_VGS_MEME			324
 
+// It would be handy
+#define UI_SHOW_ALL_FORCES  325
+
 #define VOICECHAT_GETFLAG			"getflag"				// command someone to get the flag
 #define VOICECHAT_OFFENSE			"offense"				// command someone to go on offense
 #define VOICECHAT_DEFEND			"defend"				// command someone to go on defense

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -532,7 +532,7 @@ void UI_ReadLegalForce(void)
 		}
 	}
 	//Second, legalize them.
-	if (!BG_LegalizedForcePowers(fcfString, sizeof (fcfString), uiMaxRank, ui_freeSaber.integer, forceTeam, atoi( Info_ValueForKey( info, "g_gametype" )), 0))
+	if (!BG_LegalizedForcePowers2(fcfString, sizeof(fcfString), uiMaxRank, ui_freeSaber.integer, forceTeam, atoi(Info_ValueForKey(info, "g_gametype")), 0, ui_drawTeamForces.integer))
 	{ //if they were illegal, we should refresh them.
 		updateForceLater = qtrue;
 	}

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -919,7 +919,12 @@ qboolean UI_ShowAllForces_HandleKey(int flags, float* special, int key, int num,
 		num = i;
 
 		trap->Cvar_SetValue("cg_enableForceMenu", num);
-		trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer >= GT_TEAM);
+		trap->Cvar_SetValue("ui_drawTeamForces",
+			cg_enableForceMenu.integer ||
+			ui_gametype.integer >= GT_TEAM ||
+			(uiForceSide == FORCE_LIGHTSIDE && !uiForcePowersDisabled[FP_TEAM_HEAL]) ||
+			(uiForceSide == FORCE_DARKSIDE && !uiForcePowersDisabled[FP_TEAM_FORCE])
+		);
 
 
 

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -919,7 +919,7 @@ qboolean UI_ShowAllForces_HandleKey(int flags, float* special, int key, int num,
 		num = i;
 
 		trap->Cvar_SetValue("cg_enableForceMenu", num);
-		trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer > 4);
+		trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer >= GT_TEAM);
 
 
 

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -891,6 +891,46 @@ qboolean UI_ForceSide_HandleKey(int flags, float *special, int key, int num, int
 	return qfalse;
 }
 
+qboolean UI_ShowAllForces_HandleKey(int flags, float* special, int key, int num, int min, int max, int type)
+{
+	if (key == A_MOUSE1 || key == A_MOUSE2 || key == A_ENTER || key == A_KP_ENTER)
+	{
+		int i = num;
+		int x = 0;
+
+		Menu_SetFeederSelection(NULL, FEEDER_FORCECFG, 0, NULL);
+
+		if (key == A_MOUSE2)
+		{
+			i--;
+		}
+		else
+		{
+			i++;
+		}
+		if (i < min)
+		{
+			i = max;
+		}
+		else if (i > max)
+		{
+			i = min;
+		}
+		num = i;
+
+		trap->Cvar_SetValue("cg_enableForceMenu", num);
+		trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer > 4);
+
+
+
+		UpdateForceUsed();
+		gTouchedForce = qtrue;
+
+		return qtrue;
+	}
+	return qfalse;
+}
+
 qboolean UI_JediNonJedi_HandleKey(int flags, float *special, int key, int num, int min, int max, int type)
 {
 	char info[MAX_INFO_VALUE];

--- a/codemp/ui/ui_force.h
+++ b/codemp/ui/ui_force.h
@@ -50,6 +50,7 @@ void UI_SaveForceTemplate();
 void UI_UpdateForcePowers();
 qboolean UI_SkinColor_HandleKey(int flags, float *special, int key, int num, int min, int max, int type);
 qboolean UI_ForceSide_HandleKey(int flags, float *special, int key, int num, int min, int max, int type);
+qboolean UI_ShowAllForces_HandleKey(int flags, float* special, int key, int num, int min, int max, int type);
 qboolean UI_JediNonJedi_HandleKey(int flags, float *special, int key, int num, int min, int max, int type);
 qboolean UI_ForceMaxRank_HandleKey(int flags, float *special, int key, int num, int min, int max, int type);
 qboolean UI_ForcePowerRank_HandleKey(int flags, float *special, int key, int num, int min, int max, int type);

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -2453,7 +2453,12 @@ void UpdateForceStatus(void)
 			if (!cg_enableForceMenu.integer)
 			{
 				UI_SetForceDisabled(disabledForce);
-				trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer >= GT_TEAM);
+				trap->Cvar_SetValue( "ui_drawTeamForces",
+					cg_enableForceMenu.integer || 
+					ui_gametype.integer >= GT_TEAM ||
+					(uiForceSide == FORCE_LIGHTSIDE && !uiForcePowersDisabled[FP_TEAM_HEAL]) ||
+					(uiForceSide == FORCE_DARKSIDE && !uiForcePowersDisabled[FP_TEAM_FORCE])
+				);
 			}
 			else
 			{

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -2453,12 +2453,12 @@ void UpdateForceStatus(void)
 			if (!cg_enableForceMenu.integer)
 			{
 				UI_SetForceDisabled(disabledForce);
-				trap->Cvar_Set("ui_drawTeamForces", va("%i", Info_ValueForKey(info, "cg_enableForceMenu") || ui_gametype.integer > 4));
+				trap->Cvar_SetValue("ui_drawTeamForces", cg_enableForceMenu.integer || ui_gametype.integer >= GT_TEAM);
 			}
 			else
 			{
 				UI_SetForceDisabled(0);
-				trap->Cvar_Set("ui_drawTeamForces", "1");
+				trap->Cvar_SetValue("ui_drawTeamForces", 1);
 			}
 
 			Menu_ShowItemByName(menu, "noforce", qfalse);

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -2101,6 +2101,33 @@ qboolean UI_TrueJediEnabled( void )
 	return (trueJedi != 0);
 }
 
+void UpdateForceStatus(void);
+static void UI_DrawShowAllForce(rectDef_t* rect, float scale, vec4_t color, int textStyle, int val, int min, int max, int iMenuFont)
+{
+	int i;
+	char s[256];
+
+	i = val;
+	if (i < min || i > max)
+	{
+		i = min;
+	}
+
+	if (i == 0)
+	{
+		trap->SE_GetStringTextString("MENUS_NO", s, sizeof(s));
+	}
+	else
+	{
+		trap->SE_GetStringTextString("MENUS_YES", s, sizeof(s));
+	}
+
+	UI_ReadLegalForce();
+	UpdateForceStatus();
+
+	Text_Paint(rect->x, rect->y, scale, color, s, 0, 0, textStyle, iMenuFont);
+}
+
 static void UI_DrawJediNonJedi(rectDef_t *rect, float scale, vec4_t color, int textStyle, int val, int min, int max, int iMenuFont)
 {
 	int i;
@@ -2854,6 +2881,17 @@ static int UI_OwnerDrawWidth(int ownerDraw, float scale) {
 			s = (char *)UI_GetStringEdString("MENUS", "FORCEDESC_DARK");
 		}
 		break;
+	case UI_SHOW_ALL_FORCES:
+		i = cg_enableForceMenu.integer;
+		if (i == 1)
+		{
+			s = (char*)UI_GetStringEdString("MENUS", "YES");
+		}
+		else
+		{
+			s = (char*)UI_GetStringEdString("MENUS", "NO");
+		}
+		break;
     case UI_JEDI_NONJEDI:
 		i = uiJediNonJedi;
 		if (i < 0 || i > 1)
@@ -3244,6 +3282,9 @@ static void UI_OwnerDraw(float x, float y, float w, float h, float text_x, float
 	case UI_FORCE_SIDE:
       UI_DrawForceSide(&rect, scale, color, textStyle, uiForceSide, 1, 2, iMenuFont);
       break;
+	case UI_SHOW_ALL_FORCES:
+	  UI_DrawShowAllForce(&rect, scale, color, textStyle, cg_enableForceMenu.integer, 0, 1, iMenuFont);
+	  break;
 	case UI_JEDI_NONJEDI:
       UI_DrawJediNonJedi(&rect, scale, color, textStyle, uiJediNonJedi, 0, 1, iMenuFont);
       break;
@@ -5391,6 +5432,9 @@ static qboolean UI_OwnerDrawHandleKey(int ownerDraw, int flags, float *special, 
     case UI_FORCE_SIDE:
       return UI_ForceSide_HandleKey(flags, special, key, uiForceSide, 1, 2, ownerDraw);
       break;
+	case UI_SHOW_ALL_FORCES:
+	  return UI_ShowAllForces_HandleKey(flags, special, key, cg_enableForceMenu.integer, 0, 1, ownerDraw);
+	  break;
     case UI_JEDI_NONJEDI:
       return UI_JediNonJedi_HandleKey(flags, special, key, uiJediNonJedi, 0, 1, ownerDraw);
       break;

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -2332,7 +2332,7 @@ void UpdateBotButtons(void)
 
 }
 
-void UpdateForceStatus()
+void UpdateForceStatus(void)
 {
 	menuDef_t *menu;
 
@@ -2423,9 +2423,17 @@ void UpdateForceStatus()
 		}
 		else
 		{
-			if (!cg_enableForceMenu.integer) { UI_SetForceDisabled(disabledForce); }
+			if (!cg_enableForceMenu.integer)
+			{
+				UI_SetForceDisabled(disabledForce);
+				trap->Cvar_Set("ui_drawTeamForces", va("%i", Info_ValueForKey(info, "cg_enableForceMenu") || ui_gametype.integer > 4));
+			}
 			else
+			{
 				UI_SetForceDisabled(0);
+				trap->Cvar_Set("ui_drawTeamForces", "1");
+			}
+
 			Menu_ShowItemByName(menu, "noforce", qfalse);
 			Menu_ShowItemByName(menu, "yesforce", qtrue);
 		}

--- a/codemp/ui/ui_shared.c
+++ b/codemp/ui/ui_shared.c
@@ -3015,6 +3015,7 @@ qboolean Item_OwnerDraw_HandleKey(itemDef_t *item, int key) {
 		switch( item->window.ownerDraw )
 		{
 			case UI_FORCE_SIDE:
+			case UI_SHOW_ALL_FORCES:
 			case UI_FORCE_RANK_HEAL:
 			case UI_FORCE_RANK_LEVITATION:
 			case UI_FORCE_RANK_SPEED:

--- a/codemp/ui/ui_xcvar.h
+++ b/codemp/ui/ui_xcvar.h
@@ -165,5 +165,6 @@ XCVAR_DEF( ui_headCount,					"-1",					NULL,				CVAR_ARCHIVE|CVAR_INTERNAL|CVAR_
 XCVAR_DEF( ui_showAllSkins,					"0",				CVU_UpdateModelList,	CVAR_ARCHIVE_ND )
 XCVAR_DEF( ui_sv_pure,						"0",				CVU_UpdateModelList,	CVAR_INTERNAL|/*CVAR_ROM|*/CVAR_NORESTART )
 XCVAR_DEF( ui_drawCursor,					"1",					NULL,				CVAR_NONE )
-XCVAR_DEF(cg_enableForceMenu,               "1",                    NULL,               CVAR_ARCHIVE)
+XCVAR_DEF( cg_enableForceMenu,              "1",                    NULL,               CVAR_ARCHIVE)
+XCVAR_DEF( ui_drawTeamForces,               "1",                    NULL,               CVAR_INTERNAL|CVAR_ROM )
 #undef XCVAR_DEF


### PR DESCRIPTION
Added menu support to select team force powers in FFA if the server allows them.
Added a menu button to the force selection menu to toggle the value of cg_enableForceMenu.
Changed team force checks to render the forces as selectable if the server allows them, regardless of game type.
Expanded cg_enableForceMenu to force team force powers to show up in the menu as selectable as well.
