### PR TITLE
Fix crash when dismembering players with missing bone names

### DIFF
--- a/codemp/cgame/cg_ents.c
+++ b/codemp/cgame/cg_ents.c
@@ -1297,8 +1297,13 @@ static void CG_General( centity_t *cent ) {
 
 			trap->G2API_SetRootSurface(cent->ghoul2, 0, limbName);
 
-			trap->G2API_SetNewOrigin(cent->ghoul2, trap->G2API_AddBolt(cent->ghoul2, 0, rotateBone));
-
+			{
+				int boltIndex = trap->G2API_AddBolt(cent->ghoul2, 0, rotateBone);
+				if (boltIndex != -1) {
+					trap->G2API_SetNewOrigin(cent->ghoul2, boltIndex);
+				}
+			}
+			
 			trap->G2API_SetSurfaceOnOff(cent->ghoul2, limbCapName, 0);
 
 			trap->G2API_SetSurfaceOnOff(clEnt->ghoul2, limbName, 0x00000100);

--- a/codemp/cgame/cg_ents.c
+++ b/codemp/cgame/cg_ents.c
@@ -1297,11 +1297,9 @@ static void CG_General( centity_t *cent ) {
 
 			trap->G2API_SetRootSurface(cent->ghoul2, 0, limbName);
 
-			{
-				int boltIndex = trap->G2API_AddBolt(cent->ghoul2, 0, rotateBone);
-				if (boltIndex != -1) {
-					trap->G2API_SetNewOrigin(cent->ghoul2, boltIndex);
-				}
+			int boltIndex = trap->G2API_AddBolt(cent->ghoul2, 0, rotateBone);
+			if (boltIndex != -1) {
+				trap->G2API_SetNewOrigin(cent->ghoul2, boltIndex);
 			}
 			
 			trap->G2API_SetSurfaceOnOff(cent->ghoul2, limbCapName, 0);


### PR DESCRIPTION
The specific error was : ERROR: Bad boltindex (-1) trying to SetNewOrigin (naughty naughty!)

The code change is small and pretty much self explanatory