### PR TITLE
TransitionIssues.

### DIFF
--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -553,12 +553,14 @@ CG_TransitionPlayerState
 */
 extern int cg_dueltypes[MAX_CLIENTS];//JAPRO - Clientside - Fullforce Duels
 void CG_TransitionPlayerState( playerState_t *ps, playerState_t *ops ) {
-	// check for changing follow mode
-	if ( ps->clientNum != ops->clientNum ) {
-		cg.thisFrameTeleport = qtrue;
-		// make sure we don't get any unwanted transition effects
-		*ops = *ps;
-	}
+        // check for changing follow mode
+        if ( ps->clientNum != ops->clientNum ) {
+                cg.thisFrameTeleport = qtrue;
+                cg.weaponSelect = ps->weapon;
+                cg.weaponSelectTime = cg.time;
+                // make sure we don't get any unwanted transition effects
+                *ops = *ps;
+        }
 
 	// damage events (player is getting wounded)
 	if ( ps->damageEvent != ops->damageEvent && ps->damageCount ) {


### PR DESCRIPTION
If you spectate a player who has guns, as he switches weapons, u see the weapon icons too.

Now if you join the game during him switching icons, when u turn off ur saber, ur saber icon is instead his last equipped weapon instead of the saber hilt.