### PR TITLE
Fix/linux macos build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,10 +193,10 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            runner: macos-13
-            cmake_extra: ""
+            runner: macos-15
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
           - arch: arm64
-            runner: macos-14
+            runner: macos-15
             cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_SYSTEM_PROCESSOR=arm64"
     steps:
       - name: Checkout beta branch
@@ -538,10 +538,10 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            runner: macos-13
-            cmake_extra: ""
+            runner: macos-15
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
           - arch: arm64
-            runner: macos-14
+            runner: macos-15
             cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_SYSTEM_PROCESSOR=arm64"
     steps:
       - name: Checkout master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if(MSVC)
 	set(SharedDefines ${SharedDefines} "_CRT_NONSTDC_NO_DEPRECATE")
 	#set(SharedDefines ${SharedDefines} "WINDOWS_IGNORE_PACKING_MISMATCH")
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /EHsc /arch:SSE2")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /EHsc /arch:SSE2 /we4013")
 
 	#hax flags
 	set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELEASE} /Zi /DRELWITHDEBINFO")

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -2309,6 +2309,7 @@ extern	int sortedTeamPlayers[TEAM_MAXOVERLAY];
 extern	int	numSortedTeamPlayers;
 extern  char systemChat[256];
 
+int CG_ClientNumFromName(const char *p);
 void CG_AddLagometerFrameInfo( void );
 void CG_AddSpeedGraphFrameInfo( void );
 void CG_AddLagometerSnapshotInfo( snapshot_t *snap );

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -47,6 +47,9 @@ USER INTERFACE MAIN
 
 extern void UI_SaberAttachToChar( itemDef_t *item );
 
+static qboolean bIsImageFile(const char* dirptr, const char* skinname);
+static qboolean UI_ParseColorData(char* buf, playerSpeciesInfo_t *species, char* file);
+
 const char *forcepowerDesc[NUM_FORCE_POWERS] =
 {
 	"@MENUS_OF_EFFECT_JEDI_ONLY_NEFFECT",

--- a/lib/zlib/gzguts.h
+++ b/lib/zlib/gzguts.h
@@ -3,6 +3,10 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #ifdef _LARGEFILE64_SOURCE
 #  ifndef _LARGEFILE_SOURCE
 #    define _LARGEFILE_SOURCE 1


### PR DESCRIPTION
  - Add forward declarations for `bIsImageFile`, `UI_ParseColorData`, and `CG_ClientNumFromName` to fix GCC/Clang implicit function
  declaration errors
  - Add `/we4013` MSVC flag to catch these errors on Windows too
  - Add `#include <unistd.h>` to bundled zlib `gzguts.h` for macOS `lseek` declaration
  - Switch macOS CI runners from `macos-13`/`macos-14` to `macos-15` with cross-compilation