### PR TITLE
Ghoul2 client size increase

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2989,7 +2989,7 @@ static void *CM_GetCachedMapDiskImage( void ) { return gpvCachedMapDiskImage; }
 static void CM_SetCachedMapDiskImage( void *ptr ) { gpvCachedMapDiskImage = ptr; }
 static void CM_SetUsingCache( qboolean usingCache ) { gbUsingCachedMapDataRightNow = usingCache; }
 
-#define G2_VERT_SPACE_SERVER_SIZE 1024//256
+#define G2_VERT_SPACE_SERVER_SIZE 2048 //256 originally
 IHeapAllocator *G2VertSpaceServer = NULL;
 CMiniHeap IHeapAllocator_singleton(G2_VERT_SPACE_SERVER_SIZE * 1024);
 
@@ -3663,7 +3663,7 @@ static void CL_MaxFPS_f(void) {
 	Cbuf_ExecuteText(EXEC_NOW, va("set com_maxFPS %s\n", Cmd_ArgsFrom(1)));
 }
 
-#define G2_VERT_SPACE_CLIENT_SIZE 1024
+#define G2_VERT_SPACE_CLIENT_SIZE 2048 //256 originally
 
 /*
 ===============

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -3663,7 +3663,7 @@ static void CL_MaxFPS_f(void) {
 	Cbuf_ExecuteText(EXEC_NOW, va("set com_maxFPS %s\n", Cmd_ArgsFrom(1)));
 }
 
-#define G2_VERT_SPACE_CLIENT_SIZE 256
+#define G2_VERT_SPACE_CLIENT_SIZE 1024
 
 /*
 ===============


### PR DESCRIPTION
Upped clientside Ghoul2 limit from 256 to 2056 to fix "Ghoul2: Ran out of transform space" main menu crash.
Included serverside