### PR TITLE
Strip anti-spoof token from demo recordings to prevent broken playback

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -248,9 +248,52 @@ void CL_WriteDemoMessage ( msg_t *msg, int headerBytes ) {
 
 	// skip the packet sequencing information
 	len = msg->cursize - headerBytes;
-	swlen = LittleLong(len);
-	FS_Write (&swlen, 4, clc.demofile);
-	FS_Write ( msg->data + headerBytes, len, clc.demofile );
+
+
+	// Fix for if the anti-spoof token is present in this message, strip it from the
+	// demo file. The token bit range was saved by CL_ParseServerMessage.
+	if (clc.demoTokenBitEnd > clc.demoTokenBitStart && clc.demoTokenBitStart > 0)
+	{
+		int payloadBitStart = headerBytes * 8;
+		int tokenStart = clc.demoTokenBitStart - payloadBitStart;
+		int tokenEnd = clc.demoTokenBitEnd - payloadBitStart;
+		int payloadBits = len * 8;
+		int tokenBits = tokenEnd - tokenStart;
+		int cleanBits = payloadBits - tokenBits;
+		int cleanLen = (cleanBits + 7) / 8;
+		byte cleanData[MAX_MSGLEN];
+
+		Com_Memset(cleanData, 0, cleanLen);
+
+		// Copy bits before the token (reliableAck encoding)
+		const byte *src = msg->data + headerBytes;
+		int i;
+		for (i = 0; i < tokenStart; i++)
+		{
+			if (src[i >> 3] & (1 << (i & 7)))
+				cleanData[i >> 3] |= (1 << (i & 7));
+		}
+		// Copy bits after the token (svc_* commands encoding)
+		for (i = tokenEnd; i < payloadBits; i++)
+		{
+			int dst = i - tokenBits;
+			if (src[i >> 3] & (1 << (i & 7)))
+				cleanData[dst >> 3] |= (1 << (dst & 7));
+		}
+
+		swlen = LittleLong(cleanLen);
+		FS_Write (&swlen, 4, clc.demofile);
+		FS_Write (cleanData, cleanLen, clc.demofile);
+
+		clc.demoTokenBitStart = 0;
+		clc.demoTokenBitEnd = 0;
+	}
+	else
+	{
+		swlen = LittleLong(len);
+		FS_Write (&swlen, 4, clc.demofile);
+		FS_Write ( msg->data + headerBytes, len, clc.demofile );
+	}
 }
 
 

--- a/codemp/client/cl_parse.cpp
+++ b/codemp/client/cl_parse.cpp
@@ -850,7 +850,17 @@ void CL_ParseServerMessage( msg_t *msg ) {
 
 	if (clc.unique && clc.uniqueAssigned && cl_antiSpoof->integer)
 	{
+		// Save bit position before token for demo recording stripping
+		int preTokenBit = msg->bit;
+
 		clc.reliableUnique = MSG_ReadLong(msg);
+
+		// Save token bit range so CL_WriteDemoMessage can strip it
+		if (clc.demorecording)
+		{
+			clc.demoTokenBitStart = preTokenBit;
+			clc.demoTokenBitEnd = msg->bit;
+		}
 
 		if (clc.reliableUnique != clc.unique)
 		{

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -230,6 +230,8 @@ typedef struct clientConnection_s {
 
 	int			unique;					// from the server to use for connecting
 	bool		uniqueAssigned;					// from the server to use for connecting
+	int			demoTokenBitStart;		// bit position before anti-spoof token (for demo stripping)
+	int			demoTokenBitEnd;		// bit position after anti-spoof token (for demo stripping)
 	int			challenge;					// from the server to use for connecting
 	int			checksumFeed;				// from the server for checksum calculations
 


### PR DESCRIPTION
When connected to a server with anti-spoofing enabled, the 4-byte unique token embedded in each message was being written to demo files. During playback, the parser doesn't read this token, causing Huffman-decoded message data to be misaligned and the demo to be unplayable.

Save the exact bit positions of the token during parsing and perform a bit-level strip of the encoded token from the message buffer before writing to the demo file.