### PR TITLE
Fix crash when switching from rend2 to vanilla renderer

### DIFF
--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -400,6 +400,13 @@ static rserr_t GLimp_CreateOpenGLWindow(
 	stencilBits = r_stencilbits->integer;
 	samples = r_ext_multisample->integer;
 
+	// Reset all SDL GL attributes to defaults before configuring.
+	// This prevents stale settings (e.g. rend2's Core Profile 3.2) from
+	// persisting when a different renderer creates a new context.
+	// Without this, switching from rend2 to vanilla gives vanilla a Core Profile
+	// context, causing glGetString(GL_EXTENSIONS) to return NULL and crash.
+	SDL_GL_ResetAttributes();
+
 	for (int i = 0; i < 16; i++)
 	{
 		int testColorBits, testDepthBits, testStencilBits;


### PR DESCRIPTION
rend2 requests an OpenGL Core Profile 3.2 context via SDL_GL_SetAttribute. These SDL attributes are global and persist even after the context/window is destroyed. When vanilla subsequently creates a new context without explicitly resetting the profile, it inherits rend2's Core Profile 3.2 setting. In Core Profile, glGetString(GL_EXTENSIONS) returns NULL. Vanilla then passes NULL to TruncateGLExtensionsString which calls strlen(NULL), causing a crash to desktop.

Fix by calling SDL_GL_ResetAttributes() before the context creation loop in GLimp_CreateOpenGLWindow, clearing any stale GL attributes left over from a previous renderer's initialization.