### PR TITLE
Vehicle limit increase

### DIFF
--- a/codemp/game/bg_vehicles.h
+++ b/codemp/game/bg_vehicles.h
@@ -372,7 +372,7 @@ typedef struct vehicleInfo_s {
 
 #define	VFOFS(x) offsetof(vehicleInfo_t, x)
 
-#define MAX_VEHICLES	32	//sigh... no more than 64 individual vehicles
+#define MAX_VEHICLES	128	//sigh... no more than 32 individual vehicles
 #define VEHICLE_BASE	0
 #define VEHICLE_NONE	-1
 


### PR DESCRIPTION
Upped vehicle limit increase from 32 to 128
Fixes crash to main menu with "Too many vehicles" message in console


EDIT: 
We haven't hit the limit yet so don't merge this PR until it's truly needed.

Only way to test it is to try first with all Launcher files + download a bunch of vehicles, devmap and see if we hit it.
Once confirmed, try the fix and see if it resolves that.

But yeah low priority, maybe keep this here incase it becomes relevant in future.