### PR TITLE
Feature: Force Sense 3 NPC health bars

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -7417,10 +7417,17 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 
 	//draw a health bar directly under the crosshair if we're looking at something
 	//that takes damage
-	if (crossEnt &&	crossEnt->currentState.maxhealth && cg_drawPlayerNames.integer < 2)//loda
+	if (crossEnt && crossEnt->currentState.maxhealth && cg_drawPlayerNames.integer < 2)//loda
 	{
-		CG_DrawHealthBar(crossEnt, chX, chY, w, h);
-		chY += HEALTH_HEIGHT*2;
+		// Only require Force Sense 3 for NPC health bars (not map entities like func_breakable)
+		if (!(crossEnt->currentState.number >= MAX_CLIENTS
+			&& crossEnt->currentState.eType == ET_NPC
+			&& !(cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
+				&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3)))
+		{
+			CG_DrawHealthBar(crossEnt, chX, chY, w, h);
+			chY += HEALTH_HEIGHT * 2;
+		}
 	}
 	else if (crossEnt && crossEnt->currentState.number < MAX_CLIENTS)
 	{
@@ -12010,7 +12017,15 @@ static void CG_PlayerLabels(void)
 		CG_DrawScaledProportionalString(x, y, cgs.clientinfo[i].name, UI_CENTER, colorTable[CT_WHITE], cg_drawPlayerNamesScale.value);
 
 		if (cg_drawPlayerNames.integer > 1 && cent->currentState.maxhealth)
-			CG_DrawHealthBar(cent, x, y-16, 1, 1);
+		{
+			if (!(cent->currentState.number >= MAX_CLIENTS
+				&& cent->currentState.eType == ET_NPC
+				&& !(cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
+					&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3)))
+			{
+				CG_DrawHealthBar(cent, x, y - 16, 1, 1);
+			}
+		}
 	}
 }
 

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -7417,7 +7417,7 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 
 	//draw a health bar directly under the crosshair if we're looking at something
 	//that takes damage
-	if (crossEnt && crossEnt->currentState.maxhealth && cg_drawPlayerNames.integer < 2)//loda
+	if (crossEnt && crossEnt->currentState.maxhealth)//loda
 	{
 		// Only require Force Sense 3 for NPC health bars NOT placed by mapper (shouldtarget = mapper's showhealth 1)
 		if (!(crossEnt->currentState.number >= MAX_CLIENTS

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -7419,9 +7419,10 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 	//that takes damage
 	if (crossEnt && crossEnt->currentState.maxhealth && cg_drawPlayerNames.integer < 2)//loda
 	{
-		// Only require Force Sense 3 for NPC health bars (not map entities like func_breakable)
+		// Only require Force Sense 3 for NPC health bars NOT placed by mapper (shouldtarget = mapper's showhealth 1)
 		if (!(crossEnt->currentState.number >= MAX_CLIENTS
 			&& crossEnt->currentState.eType == ET_NPC
+			&& !crossEnt->currentState.shouldtarget
 			&& !(cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
 				&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3)))
 		{
@@ -12020,6 +12021,7 @@ static void CG_PlayerLabels(void)
 		{
 			if (!(cent->currentState.number >= MAX_CLIENTS
 				&& cent->currentState.eType == ET_NPC
+				&& !cent->currentState.shouldtarget
 				&& !(cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
 					&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3)))
 			{

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -12016,18 +12016,6 @@ static void CG_PlayerLabels(void)
 			continue;
 
 		CG_DrawScaledProportionalString(x, y, cgs.clientinfo[i].name, UI_CENTER, colorTable[CT_WHITE], cg_drawPlayerNamesScale.value);
-
-		if (cg_drawPlayerNames.integer > 1 && cent->currentState.maxhealth)
-		{
-			if (!(cent->currentState.number >= MAX_CLIENTS
-				&& cent->currentState.eType == ET_NPC
-				&& !cent->currentState.shouldtarget
-				&& !(cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
-					&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3)))
-			{
-				CG_DrawHealthBar(cent, x, y - 16, 1, 1);
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Server patch sets s.maxhealth on NPCs when a player activates
Force Sense Level 3. This client-side change gates the rendering
so NPC health bars only display when the local player has Force
Sense 3 active.

- CG_DrawCrosshair: gate crosshair health bar for ET_NPC entities
- CG_PlayerLabels: gate floating label health bar for ET_NPC entities
- Map entities (func_breakable, siege objectives, etc.) unaffected
- Player entities (number < MAX_CLIENTS) unaffected