### PR TITLE
Fix extended scoreboard starting at 21 players instead of 20

### DIFF
--- a/codemp/cgame/cg_scoreboard.c
+++ b/codemp/cgame/cg_scoreboard.c
@@ -763,7 +763,7 @@ qboolean CG_DrawOldScoreboard( void ) {
 	qboolean compactHasRows = qfalse;
 	int lineHeight;
 	int topBorderSize, bottomBorderSize;
-	qboolean maxClientsScoreboard = cgs.numClients > 20;
+	qboolean maxClientsScoreboard = cgs.numClients >= 20;
 	qboolean intermissionOrDead =
 	cg.predictedPlayerState.pm_type == PM_DEAD ||
 	cg.predictedPlayerState.pm_type == PM_INTERMISSION ||


### PR DESCRIPTION
The compact/extended scoreboard layout was gated on cgs.numClients > 20, which only triggered at 21+ players. Use >= 20 so it engages at 20.