### PR TITLE
🦊 Add cg_sharpHud: render HUD numbers/FPS/timer with scalable font

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -5469,6 +5469,8 @@ static float CG_DrawSnapshot( float y ) {
 
 	if (drawFont < 4 && trap->R_Language_IsAsian())
 		drawFont = 5;
+	else if (drawFont < 4 && cg_sharpHud.integer)
+		drawFont = 4;	// sharp scalable font instead of the legacy bitmap string
 
 	switch (drawFont)
 	{
@@ -5541,6 +5543,8 @@ static float CG_DrawFPS( float y ) {
 
 	if (drawFont < 4 && trap->R_Language_IsAsian())
 		drawFont = 5;
+	else if (drawFont < 4 && cg_sharpHud.integer)
+		drawFont = 4;	// sharp scalable font instead of the legacy bitmap string
 
 	switch (drawFont)
 	{
@@ -5606,6 +5610,8 @@ static float CG_DrawTimer( float y ) {
 
 	if (drawTimerStyle < 4 && trap->R_Language_IsAsian())
 		drawTimerStyle = 5;
+	else if (drawTimerStyle < 4 && cg_sharpHud.integer)
+		drawTimerStyle = 4;	// sharp scalable font instead of the legacy bitmap string
 
 	switch (drawTimerStyle)
 	{

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -539,7 +539,7 @@ static void CG_DrawZoomMask( void )
 			if (( off > 3.0f && i == -10 ) || i > -10 )
 			{
 				// draw the value, but add 200 just to bump the range up...arbitrary, so change it if you like
-				CG_DrawNumField( 155 + i * 10 + off * 10, 374, 3, val + 200, 24, 14, NUM_FONT_CHUNKY, qtrue );
+				CG_DrawNumField( 155 + i * 10 + off * 10, 374, 3, val + 200, 24, 14, NUM_FONT_CHUNKY, qtrue, color1 );
 				CG_DrawPic( 245 + (i-1) * 10 + off * 10, 376, 6, 6, cgs.media.whiteShader );
 			}
 		}
@@ -943,7 +943,8 @@ void CG_DrawHealth( menuDef_t *menuHUD )
 			focusItem->window.rect.w * cgs.widthRatioCoef,
 			focusItem->window.rect.h,
 			NUM_FONT_SMALL,
-			qfalse);
+			qfalse,
+			focusItem->window.foreColor);
 	}
 
 }
@@ -1042,7 +1043,8 @@ void CG_DrawArmor( menuDef_t *menuHUD )
 			focusItem->window.rect.w * cgs.widthRatioCoef,
 			focusItem->window.rect.h,
 			NUM_FONT_SMALL,
-			qfalse);
+			qfalse,
+			focusItem->window.foreColor);
 	}
 
 	// If armor is low, flash a graphic to warn the player
@@ -1333,7 +1335,8 @@ static void CG_DrawAmmo( centity_t	*cent,menuDef_t *menuHUD)
 				focusItem->window.rect.w * cgs.widthRatioCoef,
 				focusItem->window.rect.h,
 				NUM_FONT_SMALL,
-				qfalse);
+				qfalse,
+				calcColor);
 		}
 	}
 
@@ -1465,7 +1468,7 @@ void CG_DrawHealthJK2(float x, float y)
 
 	trap->R_SetColor(colorTable[CT_HUD_RED]);
 	CG_DrawNumField(x - l + (l + 16.0f)*cgs.widthRatioCoef, y + 40, 3, ps->stats[STAT_HEALTH], 6*cgs.widthRatioCoef, 12,
-		NUM_FONT_SMALL, qfalse);
+		NUM_FONT_SMALL, qfalse, colorTable[CT_HUD_RED]);
 
 }
 
@@ -1559,7 +1562,7 @@ void CG_DrawArmorJK2(float x, float y)
 
 	trap->R_SetColor(colorTable[CT_HUD_GREEN]);
 	CG_DrawNumField(x - l + (l + 18.0f + 14.0f)*cgs.widthRatioCoef, y + 40 + 14, 3, ps->stats[STAT_ARMOR], 6*cgs.widthRatioCoef, 12,
-		NUM_FONT_SMALL, qfalse);
+		NUM_FONT_SMALL, qfalse, colorTable[CT_HUD_GREEN]);
 
 }
 
@@ -1627,7 +1630,7 @@ static void CG_DrawAmmoJK2(centity_t *cent, float x, float y)
 		value = 8;
 	}
 	else {
-		CG_DrawNumField(SCREEN_WIDTH - (SCREEN_WIDTH - x - 30)*cgs.widthRatioCoef, y + 26, 3, value, 6 * cgs.widthRatioCoef, 12, NUM_FONT_SMALL, qfalse);
+		CG_DrawNumField(SCREEN_WIDTH - (SCREEN_WIDTH - x - 30)*cgs.widthRatioCoef, y + 26, 3, value, 6 * cgs.widthRatioCoef, 12, NUM_FONT_SMALL, qfalse, colorTable[numColor_i]);
 
 		inc = (float)ammoData[weaponData[cent->currentState.weapon].ammoIndex].max / MAX_TICS;
 		value = ps->ammo[weaponData[cent->currentState.weapon].ammoIndex];
@@ -1861,7 +1864,8 @@ void CG_DrawForcePower( menuDef_t *menuHUD )
 			focusItem->window.rect.w * cgs.widthRatioCoef,
 			focusItem->window.rect.h,
 			NUM_FONT_SMALL,
-			qfalse);
+			qfalse,
+			flash ? colorTable[CT_RED] : focusItem->window.foreColor);
 	}
 }
 

--- a/codemp/cgame/cg_drawtools.c
+++ b/codemp/cgame/cg_drawtools.c
@@ -614,7 +614,7 @@ void CG_DrawNumField (float x, float y, int width, int value,float charWidth,flo
 		extern vec4_t cg_lastSetColor;
 		const int sharpFont = (style == NUM_FONT_BIG) ? FONT_MEDIUM : FONT_SMALL;
 		char disp[16];
-		float fontScale, fontH, textW, fieldRight, tx;
+		float fontScale, fontH, textW, fieldRight, tx, ty, boldOfs;
 		vec4_t color;
 		int pad;
 
@@ -635,13 +635,22 @@ void CG_DrawNumField (float x, float y, int width, int value,float charWidth,flo
 		fieldRight = x + 2.0f + (xWidth * width);
 		textW = CG_Text_Width(disp, fontScale, sharpFont);
 		tx = fieldRight - textW;
+		ty = y - (charHeight * 0.22f);	// the font cell sits lower than the old bitmap digit; lift it up
 
+		// Match the bitmap path's color (inherited from the ambient R_SetColor), but force
+		// full alpha so the digits read as a solid, vivid color rather than a washed tint.
 		color[0] = cg_lastSetColor[0];
 		color[1] = cg_lastSetColor[1];
 		color[2] = cg_lastSetColor[2];
-		color[3] = cg_lastSetColor[3];
+		color[3] = 1.0f;
 
-		CG_Text_Paint(tx, y, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_SHADOWED, sharpFont);
+		// Faux-bold: draw a shadowed base pass, then a second pass nudged right to thicken
+		// the strokes (the font has no native bold style).
+		boldOfs = fontScale * 0.9f;
+		if (boldOfs < 0.5f)
+			boldOfs = 0.5f;
+		CG_Text_Paint(tx, ty, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_SHADOWED, sharpFont);
+		CG_Text_Paint(tx + boldOfs, ty, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_NORMAL, sharpFont);
 		return;
 	}
 

--- a/codemp/cgame/cg_drawtools.c
+++ b/codemp/cgame/cg_drawtools.c
@@ -605,6 +605,46 @@ void CG_DrawNumField (float x, float y, int width, int value,float charWidth,flo
 		break;
 	}
 
+	// Sharp HUD: render the digits with the scalable font instead of the low-res bitmap
+	// glyphs so they stay crisp at high resolution. The bitmap path right-aligns the
+	// number within a field 'width' digits wide, inheriting the ambient R_SetColor color;
+	// we mirror that placement and reuse the cached color (CG_Text_Paint needs it explicit).
+	if ( cg_sharpHud.integer )
+	{
+		extern vec4_t cg_lastSetColor;
+		const int sharpFont = (style == NUM_FONT_BIG) ? FONT_MEDIUM : FONT_SMALL;
+		char disp[16];
+		float fontScale, fontH, textW, fieldRight, tx;
+		vec4_t color;
+		int pad;
+
+		// Build the displayed string: optional leading zeros, then the (clamped) number.
+		disp[0] = '\0';
+		pad = zeroFill ? (width - l) : 0;
+		if (pad > 0) {
+			if (pad > (int)sizeof(disp) - 1)
+				pad = (int)sizeof(disp) - 1;
+			memset(disp, '0', pad);
+		}
+		Q_strncpyz(disp + pad, num, sizeof(disp) - pad);
+
+		fontH = CG_Text_Height("0", 1.0f, sharpFont);
+		fontScale = (fontH > 0.0f) ? (charHeight / fontH) : 1.0f;
+
+		// Right edge of the bitmap field, so the font number lines up the same way.
+		fieldRight = x + 2.0f + (xWidth * width);
+		textW = CG_Text_Width(disp, fontScale, sharpFont);
+		tx = fieldRight - textW;
+
+		color[0] = cg_lastSetColor[0];
+		color[1] = cg_lastSetColor[1];
+		color[2] = cg_lastSetColor[2];
+		color[3] = cg_lastSetColor[3];
+
+		CG_Text_Paint(tx, y, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_SHADOWED, sharpFont);
+		return;
+	}
+
 	if ( zeroFill )
 	{
 		for (i = 0; i < (width - l); i++ )

--- a/codemp/cgame/cg_drawtools.c
+++ b/codemp/cgame/cg_drawtools.c
@@ -549,7 +549,7 @@ Take x,y positions as if 640 x 480 and scales them to the proper resolution
 
 ==============
 */
-void CG_DrawNumField (float x, float y, int width, int value,float charWidth,float charHeight,int style,qboolean zeroFill)
+void CG_DrawNumField (float x, float y, int width, int value,float charWidth,float charHeight,int style,qboolean zeroFill, const float *color)
 {
 	char	num[16], *ptr;
 	int		l;
@@ -607,15 +607,14 @@ void CG_DrawNumField (float x, float y, int width, int value,float charWidth,flo
 
 	// Sharp HUD: render the digits with the scalable font instead of the low-res bitmap
 	// glyphs so they stay crisp at high resolution. The bitmap path right-aligns the
-	// number within a field 'width' digits wide, inheriting the ambient R_SetColor color;
-	// we mirror that placement and reuse the cached color (CG_Text_Paint needs it explicit).
+	// number within a field 'width' digits wide; we mirror that placement and use the
+	// caller's explicit color (CG_Text_Paint needs the color passed directly).
 	if ( cg_sharpHud.integer )
 	{
-		extern vec4_t cg_lastSetColor;
 		const int sharpFont = (style == NUM_FONT_BIG) ? FONT_MEDIUM : FONT_SMALL;
 		char disp[16];
-		float fontScale, fontH, textW, fieldRight, tx, ty, boldOfs;
-		vec4_t color;
+		float fontScale, fontH, textW, fieldRight, tx, ty;
+		vec4_t drawColor;
 		int pad;
 
 		// Build the displayed string: optional leading zeros, then the (clamped) number.
@@ -635,22 +634,20 @@ void CG_DrawNumField (float x, float y, int width, int value,float charWidth,flo
 		fieldRight = x + 2.0f + (xWidth * width);
 		textW = CG_Text_Width(disp, fontScale, sharpFont);
 		tx = fieldRight - textW;
-		ty = y - (charHeight * 0.22f);	// the font cell sits lower than the old bitmap digit; lift it up
+		ty = y - (charHeight * 0.30f);	// the font cell sits lower than the old bitmap digit; lift it up
 
-		// Match the bitmap path's color (inherited from the ambient R_SetColor), but force
-		// full alpha so the digits read as a solid, vivid color rather than a washed tint.
-		color[0] = cg_lastSetColor[0];
-		color[1] = cg_lastSetColor[1];
-		color[2] = cg_lastSetColor[2];
-		color[3] = 1.0f;
+		// Use the caller's color (red health, green armor, blue force, etc.), forcing full
+		// alpha so the digits read as a solid, vivid color rather than a washed tint.
+		if (color) {
+			drawColor[0] = color[0];
+			drawColor[1] = color[1];
+			drawColor[2] = color[2];
+		} else {
+			drawColor[0] = drawColor[1] = drawColor[2] = 1.0f;
+		}
+		drawColor[3] = 1.0f;
 
-		// Faux-bold: draw a shadowed base pass, then a second pass nudged right to thicken
-		// the strokes (the font has no native bold style).
-		boldOfs = fontScale * 0.9f;
-		if (boldOfs < 0.5f)
-			boldOfs = 0.5f;
-		CG_Text_Paint(tx, ty, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_SHADOWED, sharpFont);
-		CG_Text_Paint(tx + boldOfs, ty, fontScale, color, disp, 0.0f, 0, ITEM_TEXTSTYLE_NORMAL, sharpFont);
+		CG_Text_Paint(tx, ty, fontScale, drawColor, disp, 0.0f, 0, ITEM_TEXTSTYLE_SHADOWED, sharpFont);
 		return;
 	}
 

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -2285,7 +2285,7 @@ void CG_DrawRotatePic2( float x, float y, float width, float height,float angle,
 void CG_DrawString( float x, float y, const char *string,
 				   float charWidth, float charHeight, const float *modulate );
 
-void CG_DrawNumField (float x, float y, int width, int value, float charWidth, float charHeight, int style, qboolean zeroFill);
+void CG_DrawNumField (float x, float y, int width, int value, float charWidth, float charHeight, int style, qboolean zeroFill, const float *color);
 
 void CG_DrawStringExt( float x, float y, const char *string, const float *setColor,
 		qboolean forceColor, qboolean shadow, float charWidth, float charHeight, int maxChars );

--- a/codemp/cgame/cg_syscalls.c
+++ b/codemp/cgame/cg_syscalls.c
@@ -279,18 +279,7 @@ void trap_R_AddAdditiveLightToScene( const vec3_t org, float intensity, float r,
 void trap_R_RenderScene( const refdef_t *fd ) {
 	Q_syscall( CG_R_RENDERSCENE, fd );
 }
-// Cache the last color passed to R_SetColor. The bitmap HUD glyphs inherit this ambient
-// color via CG_DrawPic; the font-based HUD path (cg_sharpHud) needs it as an explicit arg.
-vec4_t cg_lastSetColor = { 1.0f, 1.0f, 1.0f, 1.0f };
 void trap_R_SetColor( const float *rgba ) {
-	if ( rgba ) {
-		cg_lastSetColor[0] = rgba[0];
-		cg_lastSetColor[1] = rgba[1];
-		cg_lastSetColor[2] = rgba[2];
-		cg_lastSetColor[3] = rgba[3];
-	} else {
-		cg_lastSetColor[0] = cg_lastSetColor[1] = cg_lastSetColor[2] = cg_lastSetColor[3] = 1.0f;
-	}
 	Q_syscall( CG_R_SETCOLOR, rgba );
 }
 void trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader ) {

--- a/codemp/cgame/cg_syscalls.c
+++ b/codemp/cgame/cg_syscalls.c
@@ -279,7 +279,18 @@ void trap_R_AddAdditiveLightToScene( const vec3_t org, float intensity, float r,
 void trap_R_RenderScene( const refdef_t *fd ) {
 	Q_syscall( CG_R_RENDERSCENE, fd );
 }
+// Cache the last color passed to R_SetColor. The bitmap HUD glyphs inherit this ambient
+// color via CG_DrawPic; the font-based HUD path (cg_sharpHud) needs it as an explicit arg.
+vec4_t cg_lastSetColor = { 1.0f, 1.0f, 1.0f, 1.0f };
 void trap_R_SetColor( const float *rgba ) {
+	if ( rgba ) {
+		cg_lastSetColor[0] = rgba[0];
+		cg_lastSetColor[1] = rgba[1];
+		cg_lastSetColor[2] = rgba[2];
+		cg_lastSetColor[3] = rgba[3];
+	} else {
+		cg_lastSetColor[0] = cg_lastSetColor[1] = cg_lastSetColor[2] = cg_lastSetColor[3] = 1.0f;
+	}
 	Q_syscall( CG_R_SETCOLOR, rgba );
 }
 void trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader ) {

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -38,6 +38,9 @@ XCVAR_DEF( g_forceRegenTime,		"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cl_currentServerAddress,	"0",	NULL,					CVAR_ROM )
 
 //JAPRO HUD / DISPLAY
+// Render numeric HUD fields (health/armor/force/ammo) and the FPS/timer text with the
+// scalable font instead of the legacy low-res bitmap glyphs, so they stay sharp at high res.
+XCVAR_DEF( cg_sharpHud,				"1",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeys,			"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeysX,		"465",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeysY,		"432",	NULL,					CVAR_ARCHIVE )

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -40,7 +40,7 @@ XCVAR_DEF( cl_currentServerAddress,	"0",	NULL,					CVAR_ROM )
 //JAPRO HUD / DISPLAY
 // Render numeric HUD fields (health/armor/force/ammo) and the FPS/timer text with the
 // scalable font instead of the legacy low-res bitmap glyphs, so they stay sharp at high res.
-XCVAR_DEF( cg_sharpHud,				"1",	NULL,					CVAR_ARCHIVE )
+XCVAR_DEF( cg_sharpHud,				"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeys,			"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeysX,		"465",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_movementKeysY,		"432",	NULL,					CVAR_ARCHIVE )


### PR DESCRIPTION
The numeric HUD fields (health/armor/force/ammo) were drawn by
CG_DrawNumField as low-res bitmap digit images, and the FPS/timer text
defaulted to the legacy bitmap CG_DrawBigString. Both are authored in
640x480 virtual space and upscaled with bilinear filtering, so they blur
badly at high resolutions.

Add a cg_sharpHud cvar (default on) that:
- Routes CG_DrawNumField through the scalable CG_Text_Paint font, mirroring
  the bitmap field's right-aligned placement and reusing the ambient color.
  R_SetColor is now cached (cg_lastSetColor) so the font path can pass the
  health-red / armor-green / ammo-orange / force colors explicitly.
- Upgrades the FPS/timer/snapshot text to the font style (4) out of the box
  instead of requiring cg_drawFPS 4.