### PR TITLE
🦊 cgame: fix lumbar/face bone availability for NPCs

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -3736,6 +3736,38 @@ static void CG_ClearLerpFrame( centity_t *cent, clientInfo_t *ci, lerpFrame_t *l
 	}
 }
 
+static void CG_UpdateNPCBoneAvailability( centity_t *cent ) {
+	if ( cent->currentState.eType != ET_NPC )
+	{
+		return;
+	}
+
+	if ( cent->currentState.NPC_class == CLASS_VEHICLE )
+	{
+		cent->noLumbar = qtrue;
+		cent->noFace = qtrue;
+		return;
+	}
+
+	cent->noLumbar = qfalse;
+	cent->noFace = qfalse;
+
+	if ( !cent->ghoul2 )
+	{
+		return;
+	}
+
+	if ( trap->G2API_AddBolt( cent->ghoul2, 0, "lower_lumbar" ) == -1 )
+	{
+		cent->noLumbar = qtrue;
+	}
+
+	if ( trap->G2API_AddBolt( cent->ghoul2, 0, "face" ) == -1 )
+	{
+		cent->noFace = qtrue;
+	}
+}
+
 
 /*
 ===============
@@ -8930,24 +8962,7 @@ void CG_G2AnimEntModelLoad(centity_t *cent)
 				trap->G2API_AddBolt(cent->ghoul2, 0, "Motion");
 			}
 
-			// If this is a not vehicle...
-			if ( cent->currentState.NPC_class != CLASS_VEHICLE )
-			{
-				if (trap->G2API_AddBolt(cent->ghoul2, 0, "lower_lumbar") == -1)
-				{ //check now to see if we have this bone for setting anims and such
-					cent->noLumbar = qtrue;
-				}
-
-				if (trap->G2API_AddBolt(cent->ghoul2, 0, "face") == -1)
-				{ //check now to see if we have this bone for setting anims and such
-					cent->noFace = qtrue;
-				}
-			}
-			else
-			{
-				cent->noLumbar = qtrue;
-				cent->noFace = qtrue;
-			}
+			CG_UpdateNPCBoneAvailability( cent );
 
 			if (cent->localAnimIndex != -1)
 			{
@@ -13999,6 +14014,7 @@ void CG_ResetPlayerEntity( centity_t *cent )
 		//already set.
 		cent->npcLocalSurfOff = 0;
 		cent->npcLocalSurfOn = 0;
+		CG_UpdateNPCBoneAvailability( cent );
 	}
 	else
 	{
@@ -14070,6 +14086,7 @@ void CG_ResetPlayerEntity( centity_t *cent )
 
 			cent->localAnimIndex = CG_G2SkelForModel(cent->ghoul2);
 			cent->eventAnimIndex = CG_G2EvIndexForModel(cent->ghoul2, cent->localAnimIndex);
+			CG_UpdateNPCBoneAvailability( cent );
 
 			//CG_CopyG2WeaponInstance(cent->currentState.weapon, ci->ghoul2Model);
 			//cent->weapon = cent->currentState.weapon;


### PR DESCRIPTION
Cherry-pick of the lumbar fix from [TaystJK](https://github.com/taysta/TaystJK/compare/master...taysta:TaystJK:fix-lumbar), which addresses an issue we share.

### What it does
- Extracts the duplicated lumbar/face bone-checking logic out of `CG_G2AnimEntModelLoad` into a new helper `CG_UpdateNPCBoneAvailability()`.
- Calls the helper in both branches of `CG_ResetPlayerEntity` so `noLumbar`/`noFace` are recomputed — and importantly **reset to `qfalse`** — whenever an NPC's ghoul2 instance is re-created. Previously these flags could go stale and were never cleared.

### Safety note
The new helper adds an `ET_NPC` guard the original inline code didn't have. This is behavior-preserving: `CG_G2AnimEntModelLoad` is only reachable via `CG_G2Animated`, which is only invoked from the `ET_NPC` case in `cg_ents.c`, so the guard never short-circuits at that call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)