### PR TITLE
Add Discord webhook notifications for PRs and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,6 +361,25 @@ jobs:
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
 
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          DISPLAY: ${{ env.DISPLAY_VERSION }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New beta release: ${DISPLAY}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new beta build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:15844367}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"
+
   # =========================
   # ALPHA
   # =========================
@@ -701,6 +720,25 @@ jobs:
             JoF-linux-x86_64.tar.gz
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
+
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          DISPLAY: ${{ env.DISPLAY_VERSION }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New alpha release: ${DISPLAY}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new alpha build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:15844367}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"
 
   # =========================
   # MASTER (nightly/manual, only if changes)
@@ -1079,3 +1117,21 @@ jobs:
             JoF-linux-x86_64.tar.gz
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
+
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New release: ${TAG}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new stable build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:5763719}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,11 @@ permissions:
   contents: write
 
 on:
-  # Beta: build on push
+  # Beta/Alpha: build on push
   push:
     branches:
       - beta
+      - alpha
     paths-ignore:
       - "**.md"
       - ".gitignore"
@@ -344,6 +345,347 @@ jobs:
         run: |
           git tag -f latest-beta
           git push origin latest-beta --force
+
+      - name: Create GitHub prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ env.DISPLAY_VERSION }}
+          prerelease: true
+          generate_release_notes: true
+          files: |
+            JoF-windows-x86.zip
+            JoF-windows-x86_64.zip
+            JoF-linux-x86.tar.gz
+            JoF-linux-x86_64.tar.gz
+            JoF-macos-x86_64.tar.gz
+            JoF-macos-arm64.tar.gz
+
+  # =========================
+  # ALPHA
+  # =========================
+  alpha-version:
+    if: github.ref == 'refs/heads/alpha' && github.event_name == 'push'
+    name: Compute Alpha Version
+    runs-on: ubuntu-latest
+    outputs:
+      tag_version: ${{ steps.version.outputs.tag_version }}
+      base_version: ${{ steps.version.outputs.base_version }}
+      version_suffix: ${{ steps.version.outputs.version_suffix }}
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compute alpha version
+        id: version
+        shell: bash
+        run: |
+          # Find the latest non-prerelease release tag (e.g. 1.6.0)
+          LAST_RELEASE=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$LAST_RELEASE" ]; then LAST_RELEASE="0.0.0"; fi
+          echo "Base release: $LAST_RELEASE"
+
+          # Find the highest existing alpha number and increment
+          LAST_ALPHA=$(git tag --list "${LAST_RELEASE}-alpha.*" | sed "s/${LAST_RELEASE}-alpha\.//" | sort -n | tail -1)
+          if [ -z "$LAST_ALPHA" ]; then LAST_ALPHA=0; fi
+          ALPHA_NUM=$((LAST_ALPHA + 1))
+
+          TAG_VERSION="${LAST_RELEASE}-alpha.${ALPHA_NUM}"
+          VERSION_SUFFIX=" alpha ${ALPHA_NUM}"
+
+          echo "tag_version=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo "base_version=$LAST_RELEASE" >> $GITHUB_OUTPUT
+          echo "version_suffix=$VERSION_SUFFIX" >> $GITHUB_OUTPUT
+          echo "Computed version: $TAG_VERSION (base: $LAST_RELEASE, suffix: $VERSION_SUFFIX)"
+
+  windows-alpha:
+    if: github.ref == 'refs/heads/alpha' && github.event_name == 'push'
+    name: Windows ${{ matrix.arch }} Release (Alpha)
+    needs: alpha-version
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        include:
+          - arch: x86
+            platform: Win32
+          - arch: x86_64
+            platform: x64
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Download Sunny's Vulkan DLL
+        shell: bash
+        run: |
+          mkdir -p external
+          if [ "${{ matrix.arch }}" = "x86" ]; then
+            ZIP_NAME=EternalJK-windows-x86.zip
+            DLL_NAME=rd-vulkan_x86.dll
+          else
+            ZIP_NAME=EternalJK-windows-x86_64.zip
+            DLL_NAME=rd-vulkan_x86_64.dll
+          fi
+          curl -L -o external/$ZIP_NAME \
+            https://github.com/JKSunny/EternalJK/releases/download/latest/$ZIP_NAME
+          unzip -j external/$ZIP_NAME "$DLL_NAME" -d external
+          echo "RD_VULKAN_DLL=${{ github.workspace }}/external/$DLL_NAME" >> $GITHUB_ENV
+
+      - name: Create build directory
+        run: cmake -E make_directory build
+
+      - name: Configure CMake
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: |
+          cmake .. -A ${{ matrix.platform }} \
+            -DCMAKE_INSTALL_PREFIX=bin \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DJOF_VERSION_STRING="${{ needs.alpha-version.outputs.base_version }}" \
+            -DJOF_VERSION_SUFFIX="${{ needs.alpha-version.outputs.version_suffix }}" \
+            -DGIT_SHA=${{ github.sha }} \
+            -DGIT_BRANCH=${{ github.ref_name }} \
+            -DEXTERNAL_RD_VULKAN_DLL="$RD_VULKAN_DLL"
+
+      - name: Build
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --build . --config Release -j $NUMBER_OF_PROCESSORS
+
+      - name: Install
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --install . --config Release
+
+      - name: Download JoF base assets
+        shell: bash
+        run: |
+          mkdir -p build/bin/GameData/base
+          curl -L -o build/bin/GameData/base/JoF_Animations.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_Animations.pk3
+          curl -L -o build/bin/GameData/base/JoF_AssetsExtra.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_AssetsExtra.pk3
+
+      - name: Upload Alpha Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JoF-alpha-windows-${{ matrix.arch }}
+          path: build/bin
+          if-no-files-found: error
+
+  linux-alpha:
+    if: github.ref == 'refs/heads/alpha' && github.event_name == 'push'
+    name: Linux ${{ matrix.arch }} Release (Alpha)
+    needs: alpha-version
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x86_64]
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install dependencies
+        run: |
+          if [ "${{ matrix.arch }}" = "x86" ]; then
+            sudo dpkg --add-architecture i386
+            sudo apt-get -qq update
+            sudo apt-get -y install gcc-multilib g++-multilib libjpeg-dev:i386 libpng-dev:i386 zlib1g-dev:i386 libsdl2-dev:i386
+          else
+            sudo apt-get -qq update
+            sudo apt-get -y install libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev
+          fi
+
+      - name: Create build directory
+        run: cmake -E make_directory build
+
+      - name: Configure CMake
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: |
+          OPTIONS=(
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+            -DUseInternalLibs=OFF
+            -DBuildPortableVersion=OFF
+            "-DJOF_VERSION_STRING=${{ needs.alpha-version.outputs.base_version }}"
+            "-DJOF_VERSION_SUFFIX=${{ needs.alpha-version.outputs.version_suffix }}"
+            -DGIT_SHA=${{ github.sha }}
+            -DGIT_BRANCH=${{ github.ref_name }}
+          )
+          if [ "${{ matrix.arch }}" = "x86" ]; then
+            OPTIONS+=(-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/linux-i686.cmake)
+          fi
+          cmake $GITHUB_WORKSPACE "${OPTIONS[@]}"
+
+      - name: Build
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --build . -j $(nproc)
+
+      - name: Install
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --install .
+
+      - name: Download JoF base assets
+        shell: bash
+        run: |
+          mkdir -p ${{ github.workspace }}/install/JediAcademy/base
+          curl -L -o ${{ github.workspace }}/install/JediAcademy/base/JoF_Animations.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_Animations.pk3
+          curl -L -o ${{ github.workspace }}/install/JediAcademy/base/JoF_AssetsExtra.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_AssetsExtra.pk3
+
+      - name: Create binary archive
+        working-directory: ${{ github.workspace }}/install/JediAcademy
+        shell: bash
+        run: tar -czvf ${{ github.workspace }}/JoF-alpha-linux-${{ matrix.arch }}.tar.gz *
+
+      - name: Upload Alpha Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JoF-alpha-linux-${{ matrix.arch }}
+          path: ${{ github.workspace }}/JoF-alpha-linux-${{ matrix.arch }}.tar.gz
+          if-no-files-found: error
+
+  macos-alpha:
+    if: github.ref == 'refs/heads/alpha' && github.event_name == 'push'
+    name: macOS ${{ matrix.arch }} Release (Alpha)
+    needs: alpha-version
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: macos-15-intel
+            cmake_extra: ""
+          - arch: arm64
+            runner: macos-15
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_SYSTEM_PROCESSOR=arm64"
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install dependencies
+        run: |
+          brew install sdl2
+          cmake -E make_directory build
+
+      - name: Configure CMake
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: |
+          cmake $GITHUB_WORKSPACE ${{ matrix.cmake_extra }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \
+            -DUseInternalLibs=OFF \
+            -DBuildPortableVersion=OFF \
+            -DJOF_VERSION_STRING="${{ needs.alpha-version.outputs.base_version }}" \
+            -DJOF_VERSION_SUFFIX="${{ needs.alpha-version.outputs.version_suffix }}" \
+            -DGIT_SHA=${{ github.sha }} \
+            -DGIT_BRANCH=${{ github.ref_name }}
+
+      - name: Build
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --build . -j $(sysctl -n hw.ncpu)
+
+      - name: Install
+        working-directory: ${{ github.workspace }}/build
+        shell: bash
+        run: cmake --install .
+
+      - name: Download JoF base assets
+        shell: bash
+        run: |
+          mkdir -p ${{ github.workspace }}/install/JediAcademy/base
+          curl -L -o ${{ github.workspace }}/install/JediAcademy/base/JoF_Animations.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_Animations.pk3
+          curl -L -o ${{ github.workspace }}/install/JediAcademy/base/JoF_AssetsExtra.pk3 \
+            https://jofhub.eu/apps/cloud/repository/assets/JoF_AssetsExtra.pk3
+
+      - name: Create binary archive
+        working-directory: ${{ github.workspace }}/install/JediAcademy
+        shell: bash
+        run: |
+          chmod +x eternaljk.${{ matrix.arch }}.app/Contents/MacOS/eternaljk.${{ matrix.arch }}
+          tar -czvf ${{ github.workspace }}/JoF-alpha-macos-${{ matrix.arch }}.tar.gz *
+
+      - name: Upload Alpha Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: JoF-alpha-macos-${{ matrix.arch }}
+          path: ${{ github.workspace }}/JoF-alpha-macos-${{ matrix.arch }}.tar.gz
+          if-no-files-found: error
+
+  publish-alpha:
+    if: github.ref == 'refs/heads/alpha' && github.event_name == 'push'
+    name: Publish Alpha Release
+    needs: [alpha-version, windows-alpha, linux-alpha, macos-alpha]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Set version env vars
+        run: |
+          echo "TAG_VERSION=${{ needs.alpha-version.outputs.tag_version }}" >> $GITHUB_ENV
+          echo "DISPLAY_VERSION=${{ needs.alpha-version.outputs.base_version }}${{ needs.alpha-version.outputs.version_suffix }}" >> $GITHUB_ENV
+
+      - name: Create archives
+        run: |
+          zip -r JoF-windows-x86.zip     JoF-alpha-windows-x86
+          zip -r JoF-windows-x86_64.zip  JoF-alpha-windows-x86_64
+          mv JoF-alpha-linux-x86/JoF-alpha-linux-x86.tar.gz       JoF-linux-x86.tar.gz
+          mv JoF-alpha-linux-x86_64/JoF-alpha-linux-x86_64.tar.gz JoF-linux-x86_64.tar.gz
+          mv JoF-alpha-macos-x86_64/JoF-alpha-macos-x86_64.tar.gz JoF-macos-x86_64.tar.gz
+          mv JoF-alpha-macos-arm64/JoF-alpha-macos-arm64.tar.gz   JoF-macos-arm64.tar.gz
+
+      - name: Setup git authentication for tag push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/JediofFreedom/JoF_EJK.git
+
+      - name: Create version tag
+        id: tag
+        run: |
+          git tag "$TAG_VERSION"
+          git push origin "$TAG_VERSION"
+          echo "tag=$TAG_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update latest-alpha tag
+        run: |
+          git tag -f latest-alpha
+          git push origin latest-alpha --force
 
       - name: Create GitHub prerelease
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,39 @@
+name: Discord notifications
+
+# Posts a message to a Discord channel via webhook when a pull request is
+# opened. Set a repo secret named DISCORD_WEBHOOK (Discord -> Server Settings
+# -> Integrations -> Webhooks -> Copy Webhook URL).
+#
+# Uses pull_request_target so PRs from forks can also notify: that event runs
+# in the context of THIS repo and therefore has access to secrets. We only read
+# event metadata here (no checkout / no running of PR code), so it is safe.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify-pr:
+    name: Notify Discord of new PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "PR #${PR_NUMBER}: ${PR_TITLE}" \
+            --arg url "$PR_URL" \
+            --arg desc "Opened by **${PR_AUTHOR}**  •  \`${PR_HEAD}\` → \`${PR_BASE}\`" \
+            '{username:"JoF GitHub", embeds:[{title:$title, url:$url, description:$desc, color:3447003}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -2224,6 +2224,9 @@ void CG_DrawHUD(centity_t	*cent)
 		scoreStr = "";
 	}
 
+	if (cg_showClientIDs.integer && scoreStr[0])
+		scoreStr = va("%s [%i]", scoreStr, cg.snap->ps.clientNum);
+
 	if (cg.predictedPlayerState.pm_type != PM_SPECTATOR)
 	{
 		if (cgs.newHud && cg_hudFiles.integer == 1)

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -10179,6 +10179,13 @@ void CG_DrawHolsteredSaber( centity_t *cent, int time, qhandle_t *gameModels, cl
     if ( cent->currentState.eFlags & EF_DEAD )
         return;
 
+    if ( cent->currentState.powerups & ( 1 << PW_CLOAKED ) )
+    {
+        if ( !( cg.snap->ps.fd.forcePowersActive & ( 1 << FP_SEE ) )
+            || cg.snap->ps.clientNum == cent->currentState.number )
+            return;
+    }
+
     if (!cg.renderingThirdPerson && cent->currentState.clientNum == cg.clientNum)
         return;
 

--- a/codemp/cgame/cg_predict.c
+++ b/codemp/cgame/cg_predict.c
@@ -1395,7 +1395,12 @@ void CG_PredictPlayerState( void ) {
 				len = VectorLength( delta );
 				if ( len > 0.1 ) {
 					if ( cg_showMiss.integer ) {
-						trap->Print("Prediction miss: %f\n", len);
+						// dump the snapshot anim state too, to identify states (e.g. JA+
+						// knockdown get-ups) that slip past the knockdown prediction gate
+						trap->Print("Prediction miss: %f (legsAnim %d legsTimer %d torsoAnim %d torsoTimer %d fhe %d pm_type %d)\n",
+							len, cg.snap->ps.legsAnim, cg.snap->ps.legsTimer,
+							cg.snap->ps.torsoAnim, cg.snap->ps.torsoTimer,
+							cg.snap->ps.forceHandExtend, cg.snap->ps.pm_type);
 					}
 					if ( cg_errorDecay.integer ) {
 						int		t;

--- a/codemp/cgame/cg_predict.c
+++ b/codemp/cgame/cg_predict.c
@@ -1041,6 +1041,8 @@ static QINLINE int FindGrappleHook( int clientNum ) {
 }
 #endif
 
+extern qboolean PM_InKnockDown( playerState_t *ps ); //bg_panimate.c
+
 void CG_PredictPlayerState( void ) {
 	int			cmdNum, current, i;
 	playerState_t	oldPlayerState;
@@ -1078,6 +1080,23 @@ void CG_PredictPlayerState( void ) {
 
 	// non-predicting local movement will grab the latest angles
 	if ( cg_noPredict.integer || g_synchronousClients.integer || CG_UsingEWeb() ) {
+		CG_InterpolatePlayerState( qtrue );
+		if (CG_Piloting(cg.predictedPlayerState.m_iVehicleNum))
+		{
+			CG_InterpolateVehiclePlayerState(qtrue);
+		}
+		return;
+	}
+
+	// JA+ kick knockdowns: the server runs its own knockdown/get-up rules that our
+	// bg_pmove doesn't replicate, so while we're down every movement input mispredicts
+	// and the constant error corrections make the camera stutter. We can't actually
+	// move during the knockdown anyway, so prediction buys nothing there: fall back to
+	// snapshot interpolation (cg_noPredict behavior) until we're back on our feet.
+	if ( cgs.serverMod == SVMOD_JAPLUS
+		&& ( cg.snap->ps.forceHandExtend == HANDEXTEND_KNOCKDOWN
+			|| PM_InKnockDown( &cg.snap->ps ) ) )
+	{
 		CG_InterpolatePlayerState( qtrue );
 		if (CG_Piloting(cg.predictedPlayerState.m_iVehicleNum))
 		{

--- a/codemp/cgame/cg_predict.c
+++ b/codemp/cgame/cg_predict.c
@@ -1065,6 +1065,27 @@ static qboolean CG_InKnockDownState( playerState_t *ps )
 	{
 		return qtrue;
 	}
+	// JA+ kicks use these custom falling/get-up anims (seen with fhe already
+	// cleared); BG_InKnockDown only counts them on JA Pro servers, so handle
+	// them here explicitly.
+	switch ( ps->legsAnim )
+	{
+	case BOTH_BACK_FALLING:
+	case BOTH_BACK_FALLING_GETUP:
+	case BOTH_BACK_FALLING_GETUP_SLOW:
+		return qtrue;
+	default:
+		break;
+	}
+	switch ( ps->torsoAnim )
+	{
+	case BOTH_BACK_FALLING:
+	case BOTH_BACK_FALLING_GETUP:
+	case BOTH_BACK_FALLING_GETUP_SLOW:
+		return qtrue;
+	default:
+		break;
+	}
 	return qfalse;
 }
 

--- a/codemp/cgame/cg_predict.c
+++ b/codemp/cgame/cg_predict.c
@@ -1042,6 +1042,31 @@ static QINLINE int FindGrappleHook( int clientNum ) {
 #endif
 
 extern qboolean PM_InKnockDown( playerState_t *ps ); //bg_panimate.c
+extern qboolean BG_InKnockDown( int anim ); //bg_pmove.c
+
+// True from the moment we're knocked down until the get-up animation has fully
+// played out. PM_InKnockDown alone isn't enough: JA+ can play the get-up on the
+// torso channel while the legs are already free, so check both channels.
+static qboolean CG_InKnockDownState( playerState_t *ps )
+{
+	if ( ps->forceHandExtend == HANDEXTEND_KNOCKDOWN )
+	{
+		return qtrue;
+	}
+	if ( PM_InKnockDown( ps ) )
+	{
+		return qtrue;
+	}
+	if ( BG_InKnockDown( ps->legsAnim ) && ps->legsTimer > 0 )
+	{
+		return qtrue;
+	}
+	if ( BG_InKnockDown( ps->torsoAnim ) && ps->torsoTimer > 0 )
+	{
+		return qtrue;
+	}
+	return qfalse;
+}
 
 void CG_PredictPlayerState( void ) {
 	int			cmdNum, current, i;
@@ -1093,9 +1118,7 @@ void CG_PredictPlayerState( void ) {
 	// and the constant error corrections make the camera stutter. We can't actually
 	// move during the knockdown anyway, so prediction buys nothing there: fall back to
 	// snapshot interpolation (cg_noPredict behavior) until we're back on our feet.
-	if ( cgs.serverMod == SVMOD_JAPLUS
-		&& ( cg.snap->ps.forceHandExtend == HANDEXTEND_KNOCKDOWN
-			|| PM_InKnockDown( &cg.snap->ps ) ) )
+	if ( cgs.serverMod == SVMOD_JAPLUS && CG_InKnockDownState( &cg.snap->ps ) )
 	{
 		CG_InterpolatePlayerState( qtrue );
 		if (CG_Piloting(cg.predictedPlayerState.m_iVehicleNum))

--- a/codemp/cgame/cg_scoreboard.c
+++ b/codemp/cgame/cg_scoreboard.c
@@ -73,6 +73,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define SB_SCORE_X			(SB_SCORELINE_X + .55 * SB_SCORELINE_WIDTH)
 #define SB_PING_X			(SB_SCORELINE_X + .70 * SB_SCORELINE_WIDTH)
 #define SB_TIME_X			(SB_SCORELINE_X + .85 * SB_SCORELINE_WIDTH)
+#define SB_ID_X				(SB_SCORELINE_X + .97 * SB_SCORELINE_WIDTH)
 
 // The new and improved score board
 //
@@ -254,6 +255,9 @@ static void CG_DrawClientScore( int y, score_t *score, float *color, float fade,
 		CG_Text_Paint(SB_PING_X, y, 1.0f * scale, colorWhite, "-",0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL);
 		CG_Text_Paint(SB_TIME_X, y, 1.0f * scale, colorWhite, "-",0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL);
 	}
+
+	if (cg_showClientIDs.integer)
+		CG_Text_Paint(SB_ID_X, y, 1.0f * scale, colorWhite, va("%i", score->client), 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL);
 
 	// add the "ready" marker for intermission exiting
 	if ( cg.snap->ps.stats[ STAT_CLIENTS_READY ] & ( 1 << score->client ) )
@@ -525,6 +529,9 @@ static void CG_DrawClientScore2( int y, score_t *score, float *color, float fade
 		CG_Text_Paint(SB_PING_X, y, 1.0f * scale, colorWhite, "-", 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL);
 		CG_Text_Paint(SB_TIME_X, y, 1.0f * scale, colorWhite, "-", 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL);
 	}
+
+	if (cg_showClientIDs.integer)
+		CG_Text_Paint(SB_ID_X, y, 1.25f * scale, colorWhite, va("%i", score->client), 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_SMALL2);
 
 	// add the "ready" marker for intermission exiting
 	if ( cg.snap->ps.stats[ STAT_CLIENTS_READY ] & ( 1 << score->client ) )
@@ -1040,6 +1047,9 @@ qboolean CG_DrawOldScoreboard( void ) {
 		CG_Text_Paint ( SB_PING_X, y, menuHeadersScale, colorWhite, CG_GetStringEdString("MP_INGAME", "PING"), 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 		CG_Text_Paint ( SB_TIME_X, y, menuHeadersScale, colorWhite, CG_GetStringEdString("MP_INGAME", "TIME"), 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 	}
+
+	if (cg_showClientIDs.integer)
+		CG_Text_Paint(SB_ID_X, y, menuHeadersScale, colorWhite, "ID", 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM);
 
 	y = maxClientsScoreboard ? SB_TOP - 62 : SB_TOP;
 

--- a/codemp/cgame/cg_scoreboard.c
+++ b/codemp/cgame/cg_scoreboard.c
@@ -1049,7 +1049,7 @@ qboolean CG_DrawOldScoreboard( void ) {
 	}
 
 	if (cg_showClientIDs.integer)
-		CG_Text_Paint(SB_ID_X, y, menuHeadersScale, colorWhite, "ID", 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM);
+		CG_Text_Paint(SB_ID_X, y, menuHeadersScale, colorWhite, "Id", 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM);
 
 	y = maxClientsScoreboard ? SB_TOP - 62 : SB_TOP;
 

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -64,6 +64,7 @@ XCVAR_DEF( cg_drawScoreboardIcons,			"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_drawScoreboardPlayerCount,	"1",	NULL,					CVAR_ARCHIVE )
 
 XCVAR_DEF( cg_scoreDeaths,			"1",	NULL,					CVAR_ARCHIVE )
+XCVAR_DEF( cg_showClientIDs,		"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_killMessage,			"1",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_newFont,				"0",	NULL,					CVAR_ARCHIVE )
 XCVAR_DEF( cg_chatBox,				"10000",NULL,					CVAR_ARCHIVE )


### PR DESCRIPTION
Adds Discord notifications via webhook.

- **`discord-notify.yml`**: posts to Discord when a PR is opened/reopened/marked ready. Uses `pull_request_target` so fork PRs notify too.
- **`build.yml`**: a `Notify Discord` step in each `publish-beta/alpha/master` job, since `GITHUB_TOKEN`-created releases do not fire the `release` event.

All steps no-op if the `DISCORD_WEBHOOK` secret is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)