### PR TITLE
Add Discord webhook notifications for PRs and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,25 @@ jobs:
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
 
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          DISPLAY: ${{ env.DISPLAY_VERSION }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New beta release: ${DISPLAY}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new beta build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:15844367}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"
+
   # =========================
   # MASTER (nightly/manual, only if changes)
   # =========================
@@ -737,3 +756,21 @@ jobs:
             JoF-linux-x86_64.tar.gz
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
+
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New release: ${TAG}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new stable build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:5763719}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,39 @@
+name: Discord notifications
+
+# Posts a message to a Discord channel via webhook when a pull request is
+# opened. Set a repo secret named DISCORD_WEBHOOK (Discord -> Server Settings
+# -> Integrations -> Webhooks -> Copy Webhook URL).
+#
+# Uses pull_request_target so PRs from forks can also notify: that event runs
+# in the context of THIS repo and therefore has access to secrets. We only read
+# event metadata here (no checkout / no running of PR code), so it is safe.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify-pr:
+    name: Notify Discord of new PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "PR #${PR_NUMBER}: ${PR_TITLE}" \
+            --arg url "$PR_URL" \
+            --arg desc "Opened by **${PR_AUTHOR}**  •  \`${PR_HEAD}\` → \`${PR_BASE}\`" \
+            '{username:"JoF GitHub", embeds:[{title:$title, url:$url, description:$desc, color:3447003}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
Adds Discord notifications via a webhook (set the `DISCORD_WEBHOOK` repo secret: Discord → Server Settings → Integrations → Webhooks → Copy Webhook URL).

This branch is based on `master`, so it carries **only** the single notification commit into `beta` — no unrelated commits.

- **`discord-notify.yml`** — posts to Discord when a PR is opened/reopened/marked-ready. Uses `pull_request_target` so PRs from forks notify too.
- **`build.yml`** — a `Notify Discord` step in the `publish-beta` and `publish-master` jobs (the `alpha` step is added by the companion PR #100, which targets `alpha`).

### What notifications you will get

| Event | Discord ping? | Color |
|---|---|---|
| PR opened / reopened / marked-ready into a branch that has the workflow (`beta`, and `alpha` via #100) | ✅ Yes | 🔵 blue |
| Beta build published | ✅ Yes | 🟠 orange |
| Alpha build published (via #100) | ✅ Yes | 🟠 orange |
| Master / stable release published | ✅ Yes | 🟢 green |
| Plain push or commit, issue, comment, PR merge/close | ❌ No | — |

Notes:
- PR-open pings only fire for PRs into branches where `discord-notify.yml` exists. This PR adds it to `beta`; #100 adds it to `alpha`; `master` gets it whenever beta/alpha flows down.
- If the `DISCORD_WEBHOOK` secret is not set, every step skips silently — builds never break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)