### PR TITLE
Gate vehicle health bar behind Force Sense

### DIFF
--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -7446,8 +7446,13 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 				hisVeh->currentState.maxhealth &&
 				hisVeh->m_pVehicle)
 			{ //draw the health for this vehicle
-				CG_DrawHealthBar(hisVeh, chX, chY, w, h);
-				chY += HEALTH_HEIGHT*2;
+				if (hisVeh->currentState.shouldtarget
+					|| (cg.predictedPlayerState.fd.forcePowersActive & (1 << FP_SEE)
+						&& cg.predictedPlayerState.fd.forcePowerLevel[FP_SEE] >= 3))
+				{
+					CG_DrawHealthBar(hisVeh, chX, chY, w, h);
+					chY += HEALTH_HEIGHT*2;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Adds the same Force Sense 3 / `shouldtarget` gate to the third (previously missed) `CG_DrawHealthBar` call in `CG_DrawCrosshair()` (cg_draw.c) — the vehicle health bar drawn when aiming at a player riding a vehicle. Previously this call had no Force Sense gate.

Client-side only, no server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)