### PR TITLE
Stop duel music when ending duel on a musicless map

### DIFF
--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -1889,6 +1889,14 @@ void CG_StartMusic( qboolean bForceStart ) {
 	Q_strncpyz( parm1, COM_Parse( (const char **)&s ), sizeof( parm1 ) );
 	Q_strncpyz( parm2, COM_Parse( (const char **)&s ), sizeof( parm2 ) );
 
+	// musicless map: an empty CS_MUSIC means there's no track to start, so make
+	// sure anything currently playing (e.g. duel music) is stopped instead of
+	// leaving it running. S_StartBackgroundTrack won't stop it for an empty name.
+	if ( !parm1[0] ) {
+		trap->S_StopBackgroundTrack();
+		return;
+	}
+
 	trap->S_StartBackgroundTrack( parm1, parm2, !bForceStart );
 }
 


### PR DESCRIPTION
## Problem
When a private duel ends, `CG_StartMusic(qtrue)` reads the `CS_MUSIC` configstring and feeds it to `S_StartBackgroundTrack`. On a **musicless map**, `CS_MUSIC` is empty, so the intro name becomes `".mp3"` after `COM_DefaultExtension`. That name trips the leading-`.` guard in `S_StartBackgroundTrack`, which suppresses the "unable to find music" error **and** skips the `S_StopBackgroundTrack()` call. The trailing `S_StopBackgroundTrack()` is also skipped because `bCalledByCGameStart` is false.

Result: the duel track keeps playing indefinitely after the duel ends.

## Fix
Detect the empty `CS_MUSIC` case in `CG_StartMusic` and stop the background track explicitly instead of trying to start an empty one. This also correctly handles the other callsites (map restart, `CS_MUSIC` changing to empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)