### PR TITLE
Put Discord notify workflow on default branch (fixes PR pings)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,25 @@ jobs:
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
 
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          DISPLAY: ${{ env.DISPLAY_VERSION }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New beta release: ${DISPLAY}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new beta build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:15844367}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"
+
   # =========================
   # MASTER (nightly/manual, only if changes)
   # =========================
@@ -737,3 +756,21 @@ jobs:
             JoF-linux-x86_64.tar.gz
             JoF-macos-x86_64.tar.gz
             JoF-macos-arm64.tar.gz
+
+      - name: Notify Discord
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "New release: ${TAG}" \
+            --arg url "https://github.com/${REPO}/releases/tag/${TAG}" \
+            --arg desc "A new stable build is available for download." \
+            '{username:"JoF Releases", embeds:[{title:$title, url:$url, description:$desc, color:5763719}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,7 @@ jobs:
 
           # Ignore docs/md/.gitignore changes
           CHANGES=$(git diff --name-only "$LAST_COMMIT" HEAD \
-            | grep -vE '(\.md$|^\.gitignore$|^docs/)' || true)
+            | grep -vE '(\.md$|^\.gitignore$|^docs/|^\.github/)' || true)
 
           if [ -z "$CHANGES" ]; then
             echo "No relevant changes; skipping nightly/manual build."

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,39 @@
+name: Discord notifications
+
+# Posts a message to a Discord channel via webhook when a pull request is
+# opened. Set a repo secret named DISCORD_WEBHOOK (Discord -> Server Settings
+# -> Integrations -> Webhooks -> Copy Webhook URL).
+#
+# Uses pull_request_target so PRs from forks can also notify: that event runs
+# in the context of THIS repo and therefore has access to secrets. We only read
+# event metadata here (no checkout / no running of PR code), so it is safe.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify-pr:
+    name: Notify Discord of new PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK secret is not set; skipping notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "PR #${PR_NUMBER}: ${PR_TITLE}" \
+            --arg url "$PR_URL" \
+            --arg desc "Opened by **${PR_AUTHOR}**  •  \`${PR_HEAD}\` → \`${PR_BASE}\`" \
+            '{username:"JoF GitHub", embeds:[{title:$title, url:$url, description:$desc, color:3447003}]}')
+          curl -sf -H "Content-Type: application/json" -X POST -d "$payload" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
**Fix for PR notifications not firing.**

`pull_request_target` runs the workflow from the repository **default branch (`master`)**, per [GitHub docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows). `discord-notify.yml` was merged to `beta`/`alpha` (#99/#100) but never to `master`, so GitHub never registered it and it never fired.

This puts `discord-notify.yml` on `master`. With no `branches:` filter, it then covers PRs into **all** branches (beta/alpha/master) from one place. Also adds the release-notify steps to `master`'s `build.yml` so stable releases ping too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)