### PR TITLE
Async map loading via background thread (cl_asyncMapLoad)

### DIFF
--- a/codemp/client/cl_cgame.cpp
+++ b/codemp/client/cl_cgame.cpp
@@ -23,6 +23,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // cl_cgame.c  -- client system interaction with client game
 #include "client.h"
+#include <SDL.h>
+#include <atomic>
+#include <thread>
 #include "cl_cgameapi.h"
 #include "botlib/botlib.h"
 #include "FXExport.h"
@@ -739,10 +742,39 @@ void CL_InitCGame( void ) {
 
 	cls.state = CA_LOADING;
 
-	// init for this gamestate
-	// use the lastExecutedServerCommand instead of the serverCommandSequence
-	// otherwise server commands sent just before a gamestate are dropped
-	CGVM_Init( clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum );
+	static cvar_t *cl_asyncMapLoad = Cvar_Get( "cl_asyncMapLoad", "1", CVAR_ARCHIVE_ND );
+
+	if ( cl_asyncMapLoad->integer ) {
+		// Hand the GL context to the worker thread so it can do all GL work.
+		// Main thread pumps OS events so the window stays responsive during load.
+		const int loadServerSeq = clc.serverMessageSequence;
+		const int loadLastCmd   = clc.lastExecutedServerCommand;
+		const int loadClientNum = clc.clientNum;
+
+		WIN_ReleaseGLContext();
+
+		std::atomic<bool> loadDone{false};
+		std::thread loadThread([&]() {
+			WIN_ReacquireGLContext();
+			CGVM_Init( loadServerSeq, loadLastCmd, loadClientNum );
+			re->EndRegistration();
+			Com_TouchMemory();
+			WIN_ReleaseGLContext();
+			loadDone.store(true, std::memory_order_release);
+		});
+
+		while (!loadDone.load(std::memory_order_acquire)) {
+			SDL_PumpEvents();
+			Sys_Sleep(10);
+		}
+
+		loadThread.join();
+		WIN_ReacquireGLContext();
+	} else {
+		CGVM_Init( clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum );
+		re->EndRegistration();
+		Com_TouchMemory();
+	}
 
 	int clRate = Cvar_VariableIntegerValue( "rate" );
 	if ( clRate == 4000 ) {
@@ -760,16 +792,6 @@ void CL_InitCGame( void ) {
 	t2 = Sys_Milliseconds();
 
 	Com_Printf( "CL_InitCGame: %5.2f seconds\n", (t2-t1)/1000.0 );
-
-	// have the renderer touch all its images, so they are present
-	// on the card even if the driver does deferred loading
-	re->EndRegistration();
-
-	// make sure everything is paged in
-//	if (!Sys_LowPhysicalMemory())
-	{
-		Com_TouchMemory();
-	}
 
 	// clear anything that got printed
 	Con_ClearNotify ();

--- a/codemp/client/cl_cgame.cpp
+++ b/codemp/client/cl_cgame.cpp
@@ -23,9 +23,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // cl_cgame.c  -- client system interaction with client game
 #include "client.h"
-#include <SDL.h>
-#include <atomic>
-#include <thread>
 #include "cl_cgameapi.h"
 #include "botlib/botlib.h"
 #include "FXExport.h"
@@ -742,39 +739,12 @@ void CL_InitCGame( void ) {
 
 	cls.state = CA_LOADING;
 
-	static cvar_t *cl_asyncMapLoad = Cvar_Get( "cl_asyncMapLoad", "1", CVAR_ARCHIVE_ND );
-
-	if ( cl_asyncMapLoad->integer ) {
-		// Hand the GL context to the worker thread so it can do all GL work.
-		// Main thread pumps OS events so the window stays responsive during load.
-		const int loadServerSeq = clc.serverMessageSequence;
-		const int loadLastCmd   = clc.lastExecutedServerCommand;
-		const int loadClientNum = clc.clientNum;
-
-		WIN_ReleaseGLContext();
-
-		std::atomic<bool> loadDone{false};
-		std::thread loadThread([&]() {
-			WIN_ReacquireGLContext();
-			CGVM_Init( loadServerSeq, loadLastCmd, loadClientNum );
-			re->EndRegistration();
-			Com_TouchMemory();
-			WIN_ReleaseGLContext();
-			loadDone.store(true, std::memory_order_release);
-		});
-
-		while (!loadDone.load(std::memory_order_acquire)) {
-			SDL_PumpEvents();
-			Sys_Sleep(10);
-		}
-
-		loadThread.join();
-		WIN_ReacquireGLContext();
-	} else {
-		CGVM_Init( clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum );
-		re->EndRegistration();
-		Com_TouchMemory();
-	}
+	// init for this gamestate
+	// use the lastExecutedServerCommand instead of the serverCommandSequence
+	// otherwise server commands sent just before a gamestate are dropped
+	CGVM_Init( clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum );
+	re->EndRegistration();
+	Com_TouchMemory();
 
 	int clRate = Cvar_VariableIntegerValue( "rate" );
 	if ( clRate == 4000 ) {

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -27,7 +27,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "client.h"
 
 #include <limits.h>
+#include <SDL.h>
 #include <SDL_vulkan.h>
+#include <atomic>
+#include <thread>
 
 #include "ghoul2/G2.h"
 #include "qcommon/cm_public.h"
@@ -93,6 +96,8 @@ cvar_t	*m_side;
 cvar_t	*m_filter;
 
 cvar_t	*cl_activeAction;
+
+cvar_t	*cl_asyncMapLoad;
 
 cvar_t	*cl_motdString;
 
@@ -1569,16 +1574,43 @@ void CL_DownloadsComplete( void ) {
 
 	// starting to load a map so we get out of full screen ui mode
 	Cvar_Set("r_uiFullScreen", "0");
+	
+	if ( cl_asyncMapLoad->integer ) {
+		// Hand the GL context to the worker thread so it can own the full load stage.
+		// Main thread pumps OS events so the window stays responsive during connect->load.
+		WIN_ReleaseGLContext();
 
-	// flush client memory and start loading stuff
-	// this will also (re)load the UI
-	// if this is a local client then only the client part of the hunk
-	// will be cleared, note that this is done after the hunk mark has been set
-	CL_FlushMemory();
+		std::atomic<bool> loadDone{false};
+		std::thread loadThread([&]() {
+			WIN_ReacquireGLContext();
 
-	// initialize the CGame
-	cls.cgameStarted = qtrue;
-	CL_InitCGame();
+			// This includes the expensive pre-map flush/restart work before cgame init.
+			CL_FlushMemory();
+			cls.cgameStarted = qtrue;
+			CL_InitCGame();
+
+			WIN_ReleaseGLContext();
+			loadDone.store(true, std::memory_order_release);
+		});
+
+		while (!loadDone.load(std::memory_order_acquire)) {
+			SDL_PumpEvents();
+			Sys_Sleep(10);
+		}
+
+		loadThread.join();
+		WIN_ReacquireGLContext();
+	} else {
+		// flush client memory and start loading stuff
+		// this will also (re)load the UI
+		// if this is a local client then only the client part of the hunk
+		// will be cleared, note that this is done after the hunk mark has been set
+		CL_FlushMemory();
+
+		// initialize the CGame
+		cls.cgameStarted = qtrue;
+		CL_InitCGame();
+	}
 
 	// set pure checksums
 	CL_SendPureChecksums();
@@ -3800,6 +3832,8 @@ void CL_Init( void ) {
 	cl_aviMotionJpeg = Cvar_Get ("cl_aviMotionJpeg", "1", CVAR_ARCHIVE);
 	cl_avi2GBLimit = Cvar_Get ("cl_avi2GBLimit", "1", CVAR_ARCHIVE );
 	cl_forceavidemo = Cvar_Get ("cl_forceavidemo", "0", 0);
+	
+	cl_asyncMapLoad = Cvar_Get ("cl_asyncMapLoad", "1", CVAR_ARCHIVE_ND );
 
 #if JAMME_PIPES
 	cl_aviPipe = Cvar_Get("cl_aviPipe", "0", CVAR_ARCHIVE_ND, "use ffmpeg pipe for avi recording");

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -3892,7 +3892,9 @@ void CL_Init( void ) {
 	cl_avi2GBLimit = Cvar_Get ("cl_avi2GBLimit", "1", CVAR_ARCHIVE );
 	cl_forceavidemo = Cvar_Get ("cl_forceavidemo", "0", 0);
 	
-	cl_asyncMapLoad = Cvar_Get ("cl_asyncMapLoad", "1", CVAR_ARCHIVE_ND );
+	// Experimental: worker-thread map load. Known driver-dependent crash/hang
+	// modes while minimized or on HDMI mode re-sync, so off by default.
+	cl_asyncMapLoad = Cvar_Get ("cl_asyncMapLoad", "0", CVAR_ARCHIVE_ND );
 
 #if JAMME_PIPES
 	cl_aviPipe = Cvar_Get("cl_aviPipe", "0", CVAR_ARCHIVE_ND, "use ffmpeg pipe for avi recording");

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1578,6 +1578,14 @@ void CL_DownloadsComplete( void ) {
 	if ( cl_asyncMapLoad->integer ) {
 		// Hand the GL context to the worker thread so it can own the full load stage.
 		// Main thread pumps OS events so the window stays responsive during connect->load.
+
+		// Prevent SDL from calling ChangeDisplaySettingsEx on focus loss while the GL
+		// context belongs to the worker thread. On Windows, restoring the display mode
+		// while wglMakeCurrent is current on another thread can invalidate that context,
+		// turning the next GL call into an access violation (SEH) that bypasses catch(int).
+		const char *prevMinOnFocus = SDL_GetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS);
+		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+
 		WIN_ReleaseGLContext();
 
 		std::atomic<bool> loadDone{false};
@@ -1593,6 +1601,9 @@ void CL_DownloadsComplete( void ) {
 				// Com_Error throws an int; catch here so std::terminate() is not called,
 				// then re-throw on the main thread after join where Com_Frame can catch it.
 				loadError = code;
+			} catch (...) {
+				// Any other C++ exception (e.g. from a DLL) also must not escape the thread.
+				loadError = ERR_DROP;
 			}
 			WIN_ReleaseGLContext();
 			loadDone.store(true, std::memory_order_release);
@@ -1605,6 +1616,8 @@ void CL_DownloadsComplete( void ) {
 
 		loadThread.join();
 		WIN_ReacquireGLContext();
+
+		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, prevMinOnFocus ? prevMinOnFocus : "1");
 
 		if (loadError) {
 			throw loadError;

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1581,14 +1581,19 @@ void CL_DownloadsComplete( void ) {
 		WIN_ReleaseGLContext();
 
 		std::atomic<bool> loadDone{false};
+		int loadError = 0;
 		std::thread loadThread([&]() {
 			WIN_ReacquireGLContext();
-
-			// This includes the expensive pre-map flush/restart work before cgame init.
-			CL_FlushMemory();
-			cls.cgameStarted = qtrue;
-			CL_InitCGame();
-
+			try {
+				// This includes the expensive pre-map flush/restart work before cgame init.
+				CL_FlushMemory();
+				cls.cgameStarted = qtrue;
+				CL_InitCGame();
+			} catch (int code) {
+				// Com_Error throws an int; catch here so std::terminate() is not called,
+				// then re-throw on the main thread after join where Com_Frame can catch it.
+				loadError = code;
+			}
 			WIN_ReleaseGLContext();
 			loadDone.store(true, std::memory_order_release);
 		});
@@ -1600,6 +1605,10 @@ void CL_DownloadsComplete( void ) {
 
 		loadThread.join();
 		WIN_ReacquireGLContext();
+
+		if (loadError) {
+			throw loadError;
+		}
 	} else {
 		// flush client memory and start loading stuff
 		// this will also (re)load the UI

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1583,7 +1583,8 @@ void CL_DownloadsComplete( void ) {
 		// context belongs to the worker thread. On Windows, restoring the display mode
 		// while wglMakeCurrent is current on another thread can invalidate that context,
 		// turning the next GL call into an access violation (SEH) that bypasses catch(int).
-		const char *prevMinOnFocus = SDL_GetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS);
+		const char *prevMinOnFocusTmp = SDL_GetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS);
+		std::string prevMinOnFocus = prevMinOnFocusTmp ? prevMinOnFocusTmp : "";
 		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
 		WIN_ReleaseGLContext();
@@ -1617,7 +1618,8 @@ void CL_DownloadsComplete( void ) {
 		loadThread.join();
 		WIN_ReacquireGLContext();
 
-		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, prevMinOnFocus ? prevMinOnFocus : "1");
+		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS,
+			prevMinOnFocus.empty() ? "1" : prevMinOnFocus.c_str());
 
 		if (loadError) {
 			throw loadError;

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1575,7 +1575,16 @@ void CL_DownloadsComplete( void ) {
 	// starting to load a map so we get out of full screen ui mode
 	Cvar_Set("r_uiFullScreen", "0");
 	
-	if ( cl_asyncMapLoad->integer ) {
+	// Async loading is skipped when a display mode change could occur during the
+	// load (exclusive fullscreen at a non-desktop mode): a mode change while the
+	// GL context is current on the worker thread can invalidate the context and
+	// crash the process. See WIN_AsyncLoadSafe.
+	qboolean asyncSafe = WIN_AsyncLoadSafe();
+	if ( cl_asyncMapLoad->integer && !asyncSafe ) {
+		Com_Printf( "Async map load skipped: exclusive fullscreen mode differs from desktop mode\n" );
+	}
+
+	if ( cl_asyncMapLoad->integer && asyncSafe ) {
 		// Hand the GL context to the worker thread so it can own the full load stage.
 		// Main thread pumps OS events so the window stays responsive during connect->load.
 
@@ -1596,8 +1605,16 @@ void CL_DownloadsComplete( void ) {
 
 		std::atomic<bool> loadDone{false};
 		int loadError = 0;
+		bool workerRanLoad = false;
 		std::thread loadThread([&]() {
-			WIN_ReacquireGLContext();
+			if (!WIN_ReacquireGLContext()) {
+				// The context could not be made current on this thread (e.g. it
+				// was invalidated by a display change). Bail out without issuing
+				// any GL calls; the main thread will load synchronously instead.
+				loadDone.store(true, std::memory_order_release);
+				return;
+			}
+			workerRanLoad = true;
 			try {
 				// This includes the expensive pre-map flush/restart work before cgame init.
 				CL_FlushMemory();
@@ -1621,14 +1638,26 @@ void CL_DownloadsComplete( void ) {
 		}
 
 		loadThread.join();
-		WIN_ReacquireGLContext();
+		qboolean reacquired = WIN_ReacquireGLContext();
 		WIN_EndAsyncLoad();
 
 		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS,
 			prevMinOnFocus.empty() ? "1" : prevMinOnFocus.c_str());
 
+		if (!reacquired) {
+			Com_Error( ERR_FATAL, "CL_DownloadsComplete: could not restore GL context after async map load" );
+		}
+
 		if (loadError) {
 			throw loadError;
+		}
+
+		if (!workerRanLoad) {
+			// Worker never got the GL context; run the load on the main thread.
+			Com_Printf( S_COLOR_YELLOW "WARNING: async map load unavailable, loading synchronously\n" );
+			CL_FlushMemory();
+			cls.cgameStarted = qtrue;
+			CL_InitCGame();
 		}
 	} else {
 		// flush client memory and start loading stuff

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1579,13 +1579,18 @@ void CL_DownloadsComplete( void ) {
 		// Hand the GL context to the worker thread so it can own the full load stage.
 		// Main thread pumps OS events so the window stays responsive during connect->load.
 
-		// Prevent SDL from calling ChangeDisplaySettingsEx on focus loss while the GL
-		// context belongs to the worker thread. On Windows, restoring the display mode
-		// while wglMakeCurrent is current on another thread can invalidate that context,
-		// turning the next GL call into an access violation (SEH) that bypasses catch(int).
+		// Prevent SDL from calling ChangeDisplaySettingsEx while the GL context
+		// belongs to the worker thread.  Exclusive fullscreen triggers this on
+		// both focus loss (minimize path) and focus gain (restore path), either
+		// of which can invalidate a wglMakeCurrent'd context on another thread,
+		// producing an SEH access violation that bypasses catch(int).
+		// WIN_BeginAsyncLoad temporarily switches to desktop fullscreen (no
+		// ChangeDisplaySettingsEx) so focus events during the load are harmless.
+		// The minimize hint suppresses any remaining minimise-on-focus-loss path.
 		const char *prevMinOnFocusTmp = SDL_GetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS);
 		std::string prevMinOnFocus = prevMinOnFocusTmp ? prevMinOnFocusTmp : "";
 		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+		WIN_BeginAsyncLoad();
 
 		WIN_ReleaseGLContext();
 
@@ -1617,6 +1622,7 @@ void CL_DownloadsComplete( void ) {
 
 		loadThread.join();
 		WIN_ReacquireGLContext();
+		WIN_EndAsyncLoad();
 
 		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS,
 			prevMinOnFocus.empty() ? "1" : prevMinOnFocus.c_str());

--- a/codemp/qcommon/z_memman_pc.cpp
+++ b/codemp/qcommon/z_memman_pc.cpp
@@ -23,6 +23,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // Created 3/13/03 by Brian Osman (VV) - Split Zone/Hunk from common
 
 #include "client/client.h" // hi i'm bad
+#include <mutex>
 
 ////////////////////////////////////////////////
 //
@@ -94,6 +95,8 @@ typedef struct zone_s
 cvar_t	*com_validateZone;
 
 zone_t	TheZone = {};
+
+static std::recursive_mutex g_zoneMutex;
 
 
 // Scans through the linked list of mallocs and makes sure no data has been overwritten
@@ -282,37 +285,35 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit /* = qfalse */, int iU
 		}
 	}
 
-	// Link in
-	pMemory->iMagic	= ZONE_MAGIC;
-	pMemory->eTag	= eTag;
-	pMemory->iSize	= iSize;
-	pMemory->pNext  = TheZone.Header.pNext;
-	TheZone.Header.pNext = pMemory;
-	if (pMemory->pNext)
+	// Link in (mutex protects linked list and stats from concurrent CM_LoadMap thread)
 	{
-		pMemory->pNext->pPrev = pMemory;
-	}
-	pMemory->pPrev = &TheZone.Header;
-	//
-	// add tail...
-	//
-	ZoneTailFromHeader(pMemory)->iMagic = ZONE_MAGIC;
+		std::lock_guard<std::recursive_mutex> lock(g_zoneMutex);
+		pMemory->iMagic	= ZONE_MAGIC;
+		pMemory->eTag	= eTag;
+		pMemory->iSize	= iSize;
+		pMemory->pNext  = TheZone.Header.pNext;
+		TheZone.Header.pNext = pMemory;
+		if (pMemory->pNext)
+		{
+			pMemory->pNext->pPrev = pMemory;
+		}
+		pMemory->pPrev = &TheZone.Header;
+		ZoneTailFromHeader(pMemory)->iMagic = ZONE_MAGIC;
 
-	// Update stats...
-	//
-	TheZone.Stats.iCurrent += iSize;
-	TheZone.Stats.iCount++;
-	TheZone.Stats.iSizesPerTag	[eTag] += iSize;
-	TheZone.Stats.iCountsPerTag	[eTag]++;
+		TheZone.Stats.iCurrent += iSize;
+		TheZone.Stats.iCount++;
+		TheZone.Stats.iSizesPerTag	[eTag] += iSize;
+		TheZone.Stats.iCountsPerTag	[eTag]++;
 
-	if (TheZone.Stats.iCurrent > TheZone.Stats.iPeak)
-	{
-		TheZone.Stats.iPeak	= TheZone.Stats.iCurrent;
-	}
+		if (TheZone.Stats.iCurrent > TheZone.Stats.iPeak)
+		{
+			TheZone.Stats.iPeak	= TheZone.Stats.iCurrent;
+		}
 
 #ifdef DETAILED_ZONE_DEBUG_CODE
-	mapAllocatedZones[pMemory]++;
+		mapAllocatedZones[pMemory]++;
 #endif
+	}
 
 	Z_Validate();	// check for corruption
 
@@ -349,21 +350,10 @@ void Z_MorphMallocTag( void *pvAddress, memtag_t eDesiredTag )
 		return;	// won't get here
 	}
 
-	// DEC existing tag stats...
-	//
-//	TheZone.Stats.iCurrent	- unchanged
-//	TheZone.Stats.iCount	- unchanged
+	std::lock_guard<std::recursive_mutex> lock(g_zoneMutex);
 	TheZone.Stats.iSizesPerTag	[pMemory->eTag] -= pMemory->iSize;
 	TheZone.Stats.iCountsPerTag	[pMemory->eTag]--;
-
-	// morph...
-	//
 	pMemory->eTag = eDesiredTag;
-
-	// INC new tag stats...
-	//
-//	TheZone.Stats.iCurrent	- unchanged
-//	TheZone.Stats.iCount	- unchanged
 	TheZone.Stats.iSizesPerTag	[pMemory->eTag] += pMemory->iSize;
 	TheZone.Stats.iCountsPerTag	[pMemory->eTag]++;
 }
@@ -372,38 +362,37 @@ static void Zone_FreeBlock(zoneHeader_t *pMemory)
 {
 	if (pMemory->eTag != TAG_STATIC)	// belt and braces, should never hit this though
 	{
-		// Update stats...
-		//
-		TheZone.Stats.iCount--;
-		TheZone.Stats.iCurrent -= pMemory->iSize;
-		TheZone.Stats.iSizesPerTag	[pMemory->eTag] -= pMemory->iSize;
-		TheZone.Stats.iCountsPerTag	[pMemory->eTag]--;
-
-		// Sanity checks...
-		//
-		assert(pMemory->pPrev->pNext == pMemory);
-		assert(!pMemory->pNext || (pMemory->pNext->pPrev == pMemory));
-
-		// Unlink and free...
-		//
-		pMemory->pPrev->pNext = pMemory->pNext;
-		if(pMemory->pNext)
 		{
-			pMemory->pNext->pPrev = pMemory->pPrev;
-		}
-		free (pMemory);
+			std::lock_guard<std::recursive_mutex> lock(g_zoneMutex);
+			// Update stats...
+			TheZone.Stats.iCount--;
+			TheZone.Stats.iCurrent -= pMemory->iSize;
+			TheZone.Stats.iSizesPerTag	[pMemory->eTag] -= pMemory->iSize;
+			TheZone.Stats.iCountsPerTag	[pMemory->eTag]--;
 
+			// Sanity checks...
+			assert(pMemory->pPrev->pNext == pMemory);
+			assert(!pMemory->pNext || (pMemory->pNext->pPrev == pMemory));
 
-		#ifdef DETAILED_ZONE_DEBUG_CODE
-		// this has already been checked for in execution order, but wtf?
-		int& iAllocCount = mapAllocatedZones[pMemory];
-		if (iAllocCount == 0)
-		{
-			Com_Error(ERR_FATAL, "Zone_FreeBlock(): Double-freeing block!");
-			return;
+			// Unlink...
+			pMemory->pPrev->pNext = pMemory->pNext;
+			if(pMemory->pNext)
+			{
+				pMemory->pNext->pPrev = pMemory->pPrev;
+			}
+
+			#ifdef DETAILED_ZONE_DEBUG_CODE
+			int& iAllocCount = mapAllocatedZones[pMemory];
+			if (iAllocCount == 0)
+			{
+				Com_Error(ERR_FATAL, "Zone_FreeBlock(): Double-freeing block!");
+				return;
+			}
+			iAllocCount--;
+			#endif
 		}
-		iAllocCount--;
-		#endif
+		// free() is thread-safe; keep outside the mutex to avoid holding it during OS call
+		free(pMemory);
 	}
 }
 

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -1054,10 +1054,57 @@ void WIN_ReleaseGLContext( void )
 }
 
 // Make the main GL context current on the calling thread.
-void WIN_ReacquireGLContext( void )
+// Returns qfalse if the context could not be made current (e.g. it was
+// invalidated by a display mode change while owned by another thread);
+// callers must not issue GL calls in that case.
+qboolean WIN_ReacquireGLContext( void )
 {
-	if ( opengl_context )
-		SDL_GL_MakeCurrent( screen, opengl_context );
+	if ( !opengl_context )
+		return qtrue;
+	if ( SDL_GL_MakeCurrent( screen, opengl_context ) != 0 ) {
+		Com_Printf( S_COLOR_YELLOW "WIN_ReacquireGLContext: SDL_GL_MakeCurrent failed: %s\n", SDL_GetError() );
+		return qfalse;
+	}
+	return qtrue;
+}
+
+// Async map load hands the GL context to a worker thread. That is only safe
+// while no display mode change (ChangeDisplaySettingsEx on Windows) can occur,
+// because a mode change can invalidate a context that is current on another
+// thread and the next GL call then dies with an access violation.
+// WIN_BeginAsyncLoad sidesteps focus-driven mode changes by switching to
+// desktop fullscreen for the duration of the load, but that switch itself is a
+// real mode change whenever the exclusive fullscreen mode differs from the
+// desktop mode. On some display links (HDMI notably) a real mode change
+// re-syncs the link for seconds and can even flap a monitor
+// disconnect/reconnect mid-load. So async is only considered safe when the
+// window is not exclusive fullscreen, or its mode already matches the desktop
+// mode (the fullscreen-desktop round trip then changes nothing).
+qboolean WIN_AsyncLoadSafe( void )
+{
+	if ( !screen )
+		return qtrue;
+
+	Uint32 flags = SDL_GetWindowFlags( screen );
+	if ( ( flags & SDL_WINDOW_FULLSCREEN_DESKTOP ) != SDL_WINDOW_FULLSCREEN )
+		return qtrue; // windowed or desktop fullscreen: no mode change possible
+
+	int displayIndex = SDL_GetWindowDisplayIndex( screen );
+	SDL_DisplayMode fsMode, desktopMode;
+	if ( displayIndex < 0 ||
+		SDL_GetWindowDisplayMode( screen, &fsMode ) != 0 ||
+		SDL_GetDesktopDisplayMode( displayIndex, &desktopMode ) != 0 )
+	{
+		return qfalse; // can't verify the modes match: assume unsafe
+	}
+
+	if ( fsMode.w == desktopMode.w && fsMode.h == desktopMode.h &&
+		fsMode.refresh_rate == desktopMode.refresh_rate &&
+		fsMode.format == desktopMode.format )
+	{
+		return qtrue;
+	}
+	return qfalse;
 }
 
 static bool g_asyncLoadTemporaryDesktopFS = false;

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -1060,6 +1060,49 @@ void WIN_ReacquireGLContext( void )
 		SDL_GL_MakeCurrent( screen, opengl_context );
 }
 
+static bool g_asyncLoadTemporaryDesktopFS = false;
+
+// Called on the main thread (which still owns the GL context) before handing
+// the GL context to the async load worker thread.
+//
+// Exclusive fullscreen (SDL_WINDOW_FULLSCREEN) makes SDL call
+// ChangeDisplaySettingsEx in its WM_ACTIVATEAPP handler — including on focus
+// GAIN to restore the fullscreen display mode — regardless of the
+// SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS hint.  That display-mode change can
+// invalidate a wglMakeCurrent'd context on another thread, producing an SEH
+// access violation that bypasses catch(int) and kills the process.
+//
+// Desktop fullscreen (SDL_WINDOW_FULLSCREEN_DESKTOP) is a borderless window
+// at the current desktop resolution; SDL never calls ChangeDisplaySettingsEx
+// for it, so focus events during the worker-thread load are safe.  We switch
+// to it here (main thread, GL context valid) and restore exclusive fullscreen
+// in WIN_EndAsyncLoad (main thread, after GL context is reclaimed).
+void WIN_BeginAsyncLoad( void )
+{
+	g_asyncLoadTemporaryDesktopFS = false;
+	if ( !screen )
+		return;
+	Uint32 flags = SDL_GetWindowFlags( screen );
+	// SDL_WINDOW_FULLSCREEN_DESKTOP == (SDL_WINDOW_FULLSCREEN | 0x1000).
+	// Match exactly SDL_WINDOW_FULLSCREEN to detect exclusive (not desktop) mode.
+	if ( ( flags & SDL_WINDOW_FULLSCREEN_DESKTOP ) == SDL_WINDOW_FULLSCREEN )
+	{
+		if ( SDL_SetWindowFullscreen( screen, SDL_WINDOW_FULLSCREEN_DESKTOP ) == 0 )
+			g_asyncLoadTemporaryDesktopFS = true;
+	}
+}
+
+// Called on the main thread after reclaiming the GL context from the async
+// load worker thread.  Restores exclusive fullscreen if WIN_BeginAsyncLoad
+// switched it away.
+void WIN_EndAsyncLoad( void )
+{
+	if ( !screen || !g_asyncLoadTemporaryDesktopFS )
+		return;
+	SDL_SetWindowFullscreen( screen, SDL_WINDOW_FULLSCREEN );
+	g_asyncLoadTemporaryDesktopFS = false;
+}
+
 //#if WIN32
 //qboolean WIN_VK_GetInstanceExtensions(
 //	unsigned int *extensionCount,

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -1046,6 +1046,20 @@ qboolean WIN_GL_ExtensionSupported( const char *extension )
 	return SDL_GL_ExtensionSupported( extension ) == SDL_TRUE ? qtrue : qfalse;
 }
 
+// Release the GL context from the calling thread so another thread can acquire it.
+void WIN_ReleaseGLContext( void )
+{
+	if ( opengl_context )
+		SDL_GL_MakeCurrent( screen, NULL );
+}
+
+// Make the main GL context current on the calling thread.
+void WIN_ReacquireGLContext( void )
+{
+	if ( opengl_context )
+		SDL_GL_MakeCurrent( screen, opengl_context );
+}
+
 //#if WIN32
 //qboolean WIN_VK_GetInstanceExtensions(
 //	unsigned int *extensionCount,

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -214,6 +214,8 @@ void *		WIN_GL_GetProcAddress( const char *proc );
 qboolean	WIN_GL_ExtensionSupported( const char *extension );
 void		WIN_ReleaseGLContext( void );
 void		WIN_ReacquireGLContext( void );
+void		WIN_BeginAsyncLoad( void );
+void		WIN_EndAsyncLoad( void );
 
 //#if WIN32 && !defined(DEDICATED)
 //qboolean	WIN_VK_GetInstanceExtensions( unsigned int *extensionCount, const char *extensions[] );

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -213,9 +213,10 @@ void		WIN_Shutdown( void );
 void *		WIN_GL_GetProcAddress( const char *proc );
 qboolean	WIN_GL_ExtensionSupported( const char *extension );
 void		WIN_ReleaseGLContext( void );
-void		WIN_ReacquireGLContext( void );
+qboolean	WIN_ReacquireGLContext( void );
 void		WIN_BeginAsyncLoad( void );
 void		WIN_EndAsyncLoad( void );
+qboolean	WIN_AsyncLoadSafe( void );
 
 //#if WIN32 && !defined(DEDICATED)
 //qboolean	WIN_VK_GetInstanceExtensions( unsigned int *extensionCount, const char *extensions[] );

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -212,6 +212,8 @@ void		WIN_SetGamma( glconfig_t *glConfig, byte red[256], byte green[256], byte b
 void		WIN_Shutdown( void );
 void *		WIN_GL_GetProcAddress( const char *proc );
 qboolean	WIN_GL_ExtensionSupported( const char *extension );
+void		WIN_ReleaseGLContext( void );
+void		WIN_ReacquireGLContext( void );
 
 //#if WIN32 && !defined(DEDICATED)
 //qboolean	WIN_VK_GetInstanceExtensions( unsigned int *extensionCount, const char *extensions[] );


### PR DESCRIPTION
CGVM_Init and re->EndRegistration now run on a worker thread that owns the GL context, while the main thread pumps SDL events so the window stays responsive (minimize, alt-tab) during map load.

Adds cl_asyncMapLoad cvar (default 1, archived) to toggle back to the original synchronous path. Also makes the zone allocator thread-safe with a recursive_mutex around list/stats manipulation.