### PR TITLE
Don't drop client when server has sv_allowDownload 0

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1755,7 +1755,9 @@ void CL_InitDownloads(void) {
 		if ( *clc.downloadList ) {
 			const char *serverInfo = cl.gameState.stringData + cl.gameState.stringOffsets[ CS_SERVERINFO ];
 			if ( !atoi( Info_ValueForKey( serverInfo, "sv_allowDownload" ) ) ) {
-				Com_Error( ERR_DROP, "Server does not allow file downloads (sv_allowDownload 0).\nYou are missing required files:\n%s", clc.downloadList );
+				// Server doesn't allow downloads — behave as if cl_allowDownload were 0
+				Com_Printf( "\nWARNING: Server does not allow file downloads (sv_allowDownload 0).\nYou might not be able to join the game\nYou are missing required files:\n%s\n", clc.downloadList );
+				CL_DownloadsComplete();
 				return;
 			}
 


### PR DESCRIPTION
When `cl_allowDownload` is enabled but the server doesn't allow downloads (`sv_allowDownload 0`), fall back to the `cl_allowDownload 0` behavior (warning + proceed) instead of kicking the client back to the menu with `ERR_DROP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)