### PR TITLE
Add cvars to control chatbox on unfocus/minimize

### DIFF
--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -1708,7 +1708,7 @@ void CL_CmdButtons( usercmd_t *cmd ) {
 		}
 	}
 
-	if ( Key_GetCatcher( ) || com_unfocused->integer || com_minimized->integer ) {
+	if ( Key_GetCatcher( ) || cl_unfocusedChatbox->integer && com_unfocused->integer || cl_minimizedChatbox->integer && com_minimized->integer) {
 		cmd->buttons |= BUTTON_TALK;
 	}
 

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -138,6 +138,9 @@ cvar_t	*cl_afkPrefix;
 cvar_t	*cl_afkTime;
 cvar_t	*cl_afkTimeUnfocused;
 
+cvar_t* cl_unfocusedChatbox;
+cvar_t* cl_minimizedChatbox;
+
 cvar_t	*cl_logChat;
 
 cvar_t	*ui_vulkan_supported;
@@ -3980,6 +3983,9 @@ void CL_Init( void ) {
 	cl_afkPrefix = Cvar_Get("cl_afkPrefix", "[AFK]", CVAR_ARCHIVE, "Prefix to add to player name when AFK");
 	cl_unfocusedTime = 0;
 	cl_afkPrefix->modified = qfalse;
+
+	cl_unfocusedChatbox = Cvar_Get("cl_unfocusedChatbox", "1", CVAR_ARCHIVE_ND, "Automatically show chatbox balloon when the game is unfocused");
+	cl_minimizedChatbox = Cvar_Get("cl_minimizedChatbox", "1", CVAR_ARCHIVE_ND, "Automatically show chatbox balloon when the game is minimised");
 
 	cl_logChat = Cvar_Get("cl_logChat", "0", CVAR_ARCHIVE, "Toggle engine chat logs");
 

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -537,6 +537,9 @@ extern cvar_t	*cl_afkPrefix;
 extern cvar_t	*cl_afkTime;
 extern cvar_t	*cl_afkTimeUnfocused;
 
+extern cvar_t	*cl_unfocusedChatbox;
+extern cvar_t	*cl_minimizedChatbox;
+
 extern cvar_t	*cl_logChat;
 
 #if defined(DISCORD) && defined(FINAL_BUILD)


### PR DESCRIPTION
Introduce `cl_unfocusedChatbox` and `cl_minimizedChatbox` cvars to control automatic chatbox balloon display when the game is unfocused or minimized.
Updated CL_CmdButtons logic to respect these settings, giving users more flexibility over chatbox behavior when the window is inactive, for example allowing for testing damages with two clients.
Both cvars are enabled by default, reflecting the previously default behaviour of automatically displaying the chatbox balloon.