### PR TITLE
Plugin 10 logic inverted, now it says enabled when you can ledge grab

### DIFF
--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1577,8 +1577,8 @@ static const int MAX_PLUGINDISABLES = ARRAY_LEN( pluginDisables );
 
 static qboolean CG_PluginOptionEnabled(int index)
 {
-	if (index == 9)
-	{ // Plugin 9 is inverted: bit set means option disabled
+	if (index == 9 || index == 10)
+	{ // Plugins 9 and 10 (holstered saber, ledge grab) are inverted: bit set means option disabled
 		return !(cp_pluginDisable.integer & (1 << index));
 	}
 
@@ -1644,7 +1644,7 @@ void CG_PluginDisable_f( void ) {
 		trap->Cvar_Set( "cp_pluginDisable", va( "%i", (1 << index2) ^ (cp_pluginDisable.integer & mask ) ) );
 		trap->Cvar_Update( &cp_pluginDisable );
 
-		Com_Printf( "%s %s^7\n", pluginDisables[index2].string, (CG_PluginOptionEnabled(i)
+		Com_Printf( "%s %s^7\n", pluginDisables[index2].string, (CG_PluginOptionEnabled(index2)
 			? "^2Enabled" : "^1Disabled") );
 	}
 }

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -187,7 +187,7 @@ XCVAR_DEF( cg_drawHud,							"1",		NULL,				CVAR_ARCHIVE )
 
 XCVAR_DEF( cg_predictKnockback,					"0",		NULL,				0 )
 
-XCVAR_DEF( cp_pluginDisable,					"1536",		NULL,				CVAR_ARCHIVE|CVAR_USERINFO ) //'enable' ledge grab (1536)
+XCVAR_DEF( cp_pluginDisable,					"512",		NULL,				CVAR_ARCHIVE|CVAR_USERINFO ) //bits mean disable: 512 = holstered saber off, ledge grab on
 XCVAR_DEF( com_maxFPS,							"125",		NULL,				CVAR_ARCHIVE )
 XCVAR_DEF( cg_displayCameraPosition,		"1 80 16",		NULL,				CVAR_ROM|CVAR_USERINFO )
 XCVAR_DEF( cg_displayNetSettings,			"125 0 125",	NULL,				CVAR_ROM|CVAR_USERINFO )


### PR DESCRIPTION
## Summary
- Treat plugin 10 (ledge grab) as inverted in `CG_PluginOptionEnabled`, same as plugin 9: a set bit in `cp_pluginDisable` means the option is disabled, so the console now correctly reports **Enabled** when ledge grab is available.
- Fix `CG_PluginDisable_f` printing the status of the wrong plugin (`i` instead of `index2`) when toggling by name.
- Change the `cp_pluginDisable` default from `1536` to `512` so ledge grab is enabled out of the box (bit 512 keeps holstered saber off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)