### PR TITLE
fix(cgame): play local player server sounds from snapshot

### DIFF
--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -1064,6 +1064,7 @@ typedef struct cg_s {
 
 	int			eventSequence;
 	int			predictableEvents[MAX_PREDICTED_EVENTS];
+	int			lastExternalEvent;		// last ps.externalEvent played, so the predicted and snapshot dispatch paths don't double-play
 
 	float		stepChange;				// for stair up smoothing
 	int			stepTime;
@@ -2575,6 +2576,7 @@ void CG_ShaderStateChanged(void);
 int CG_IsMindTricked(int trickIndex1, int trickIndex2, int trickIndex3, int trickIndex4, int client);
 void CG_Respawn( void );
 void CG_TransitionPlayerState( playerState_t *ps, playerState_t *ops );
+void CG_CheckExternalEvent( playerState_t *ps, playerState_t *ops );
 void CG_CheckChangedPredictableEvents( playerState_t *ps );
 
 

--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -246,16 +246,6 @@ void CG_CheckPlayerstateEvents( playerState_t *ps, playerState_t *ops ) {
 			|| (i > ops->eventSequence - MAX_PS_EVENTS && ps->events[i & (MAX_PS_EVENTS-1)] != ops->events[i & (MAX_PS_EVENTS-1)]) ) {
 
 			event = ps->events[ i & (MAX_PS_EVENTS-1) ];
-
-			// EV_GENERAL_SOUND is played from the server snapshot in
-			// CG_CheckServerSoundEvents; prediction replay can overwrite it
-			// in this ring before it fires here
-			if ( event == EV_GENERAL_SOUND ) {
-				cg.predictableEvents[ i & (MAX_PREDICTED_EVENTS-1) ] = event;
-				cg.eventSequence++;
-				continue;
-			}
-
 			cent->currentState.event = event;
 			cent->currentState.eventParm = ps->eventParms[ i & (MAX_PS_EVENTS-1) ];
 //JLF ADDED to hopefully mark events as player event

--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -221,6 +221,44 @@ void CG_Respawn( void ) {
 
 /*
 ==============
+CG_CheckExternalEvent
+
+Plays a server-injected event (ps.externalEvent, set by G_AddEvent on a
+client entity). Called with the predicted playerstate pair from
+CG_CheckPlayerstateEvents and with the authoritative snapshot pair from
+CG_TransitionSnapshot: under prediction the predicted-pair comparison can
+miss the event (e.g. the EV_FALL splat of a flung player was never heard
+by the victim), so the snapshot pair is checked as well.
+cg.lastExternalEvent keeps the two paths from double-playing.
+==============
+*/
+void CG_CheckExternalEvent( playerState_t *ps, playerState_t *ops ) {
+	centity_t	*cent;
+
+	if ( !ps->externalEvent ) {
+		cg.lastExternalEvent = 0;
+		return;
+	}
+
+	if ( ps->clientNum != ops->clientNum ) {
+		// view changed (follow switch), don't replay the new view's pending event
+		cg.lastExternalEvent = ps->externalEvent;
+		return;
+	}
+
+	if ( ps->externalEvent == ops->externalEvent || ps->externalEvent == cg.lastExternalEvent ) {
+		return;
+	}
+	cg.lastExternalEvent = ps->externalEvent;
+
+	cent = &cg_entities[ ps->clientNum ];
+	cent->currentState.event = ps->externalEvent;
+	cent->currentState.eventParm = ps->externalEventParm;
+	CG_EntityEvent( cent, cent->lerpOrigin );
+}
+
+/*
+==============
 CG_CheckPlayerstateEvents
 ==============
 */
@@ -229,12 +267,7 @@ void CG_CheckPlayerstateEvents( playerState_t *ps, playerState_t *ops ) {
 	int			event;
 	centity_t	*cent;
 
-	if ( ps->externalEvent && ps->externalEvent != ops->externalEvent ) {
-		cent = &cg_entities[ ps->clientNum ];
-		cent->currentState.event = ps->externalEvent;
-		cent->currentState.eventParm = ps->externalEventParm;
-		CG_EntityEvent( cent, cent->lerpOrigin );
-	}
+	CG_CheckExternalEvent( ps, ops );
 
 	cent = &cg_entities[ ps->clientNum ];
 	// go through the predictable events buffer

--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -246,6 +246,16 @@ void CG_CheckPlayerstateEvents( playerState_t *ps, playerState_t *ops ) {
 			|| (i > ops->eventSequence - MAX_PS_EVENTS && ps->events[i & (MAX_PS_EVENTS-1)] != ops->events[i & (MAX_PS_EVENTS-1)]) ) {
 
 			event = ps->events[ i & (MAX_PS_EVENTS-1) ];
+
+			// EV_GENERAL_SOUND is played from the server snapshot in
+			// CG_CheckServerSoundEvents; prediction replay can overwrite it
+			// in this ring before it fires here
+			if ( event == EV_GENERAL_SOUND ) {
+				cg.predictableEvents[ i & (MAX_PREDICTED_EVENTS-1) ] = event;
+				cg.eventSequence++;
+				continue;
+			}
+
 			cent->currentState.event = event;
 			cent->currentState.eventParm = ps->eventParms[ i & (MAX_PS_EVENTS-1) ];
 //JLF ADDED to hopefully mark events as player event

--- a/codemp/cgame/cg_snapshot.c
+++ b/codemp/cgame/cg_snapshot.c
@@ -173,49 +173,6 @@ void CG_SetInitialSnapshot( snapshot_t *snap ) {
 
 
 /*
-==================
-CG_CheckServerSoundEvents
-
-Server-injected sound events ride the playerState event ring, which only
-holds MAX_PS_EVENTS (2) entries. Under client prediction, the Pmove replay
-in CG_PredictPlayerState appends predicted events (footsteps, jumps) to the
-same ring and can overwrite a server sound before CG_TransitionPlayerState
-plays it, so the local player never heard their own server-driven sounds
-unless cg_nopredict was set. Play them straight off the server snapshot,
-where the event sequence is authoritative; CG_CheckPlayerstateEvents skips
-EV_GENERAL_SOUND so they can't double-play.
-==================
-*/
-static void CG_CheckServerSoundEvents( playerState_t *ps, playerState_t *ops ) {
-	int			i;
-
-	if ( ps->clientNum != ops->clientNum ) {
-		return;	// follow target changed, the event sequences are unrelated
-	}
-
-	for ( i = ps->eventSequence - MAX_PS_EVENTS; i < ps->eventSequence; i++ ) {
-		if ( i < ops->eventSequence ) {
-			continue;
-		}
-		if ( ps->events[ i & (MAX_PS_EVENTS-1) ] == EV_GENERAL_SOUND ) {
-			int parm = ps->eventParms[ i & (MAX_PS_EVENTS-1) ];
-
-			// play directly instead of routing through CG_EntityEvent with a
-			// faked entityState: the playerState carries no sound channel, and
-			// EV_GENERAL_SOUND would misread saberEntityNum as one (a saber
-			// entity number of 52-55 lands on the TRACK_CHANNEL force-loop
-			// path and leaks looping sounds)
-			if ( cgs.gameSounds[ parm ] ) {
-				trap->S_StartSound( NULL, ps->clientNum, CHAN_AUTO, cgs.gameSounds[ parm ] );
-			} else {
-				const char *s = CG_ConfigString( CS_SOUNDS + parm );
-				trap->S_StartSound( NULL, ps->clientNum, CHAN_AUTO, CG_CustomSound( ps->clientNum, s ) );
-			}
-		}
-	}
-}
-
-/*
 ===================
 CG_TransitionSnapshot
 
@@ -280,10 +237,6 @@ static void CG_TransitionSnapshot( void ) {
 		else if (cg_cameraFPS.integer >= CAMERA_MIN_FPS) {
 			cg.thisFrameTeleport = qfalse; // clear for interpolated player with new camera damping
 		}
-
-		// server-driven sounds are played from the snapshot so prediction
-		// replay can't clobber them (see CG_CheckServerSoundEvents)
-		CG_CheckServerSoundEvents( ps, ops );
 
 		// if we are not doing client side movement prediction for any
 		// reason, then the client events and view changes will be issued now

--- a/codemp/cgame/cg_snapshot.c
+++ b/codemp/cgame/cg_snapshot.c
@@ -244,6 +244,13 @@ static void CG_TransitionSnapshot( void ) {
 			|| cg_noPredict.integer || g_synchronousClients.integer || CG_UsingEWeb() ) {
 			CG_TransitionPlayerState( ps, ops );
 		}
+		else {
+			// under prediction, server-injected events (ps.externalEvent) can
+			// be missed by the predicted-pair transition in
+			// CG_PredictPlayerState; dispatch them off the authoritative
+			// snapshot pair (deduped via cg.lastExternalEvent)
+			CG_CheckExternalEvent( ps, ops );
+		}
 	}
 
 }

--- a/codemp/cgame/cg_snapshot.c
+++ b/codemp/cgame/cg_snapshot.c
@@ -173,6 +173,49 @@ void CG_SetInitialSnapshot( snapshot_t *snap ) {
 
 
 /*
+==================
+CG_CheckServerSoundEvents
+
+Server-injected sound events ride the playerState event ring, which only
+holds MAX_PS_EVENTS (2) entries. Under client prediction, the Pmove replay
+in CG_PredictPlayerState appends predicted events (footsteps, jumps) to the
+same ring and can overwrite a server sound before CG_TransitionPlayerState
+plays it, so the local player never heard their own server-driven sounds
+unless cg_nopredict was set. Play them straight off the server snapshot,
+where the event sequence is authoritative; CG_CheckPlayerstateEvents skips
+EV_GENERAL_SOUND so they can't double-play.
+==================
+*/
+static void CG_CheckServerSoundEvents( playerState_t *ps, playerState_t *ops ) {
+	int			i;
+
+	if ( ps->clientNum != ops->clientNum ) {
+		return;	// follow target changed, the event sequences are unrelated
+	}
+
+	for ( i = ps->eventSequence - MAX_PS_EVENTS; i < ps->eventSequence; i++ ) {
+		if ( i < ops->eventSequence ) {
+			continue;
+		}
+		if ( ps->events[ i & (MAX_PS_EVENTS-1) ] == EV_GENERAL_SOUND ) {
+			int parm = ps->eventParms[ i & (MAX_PS_EVENTS-1) ];
+
+			// play directly instead of routing through CG_EntityEvent with a
+			// faked entityState: the playerState carries no sound channel, and
+			// EV_GENERAL_SOUND would misread saberEntityNum as one (a saber
+			// entity number of 52-55 lands on the TRACK_CHANNEL force-loop
+			// path and leaks looping sounds)
+			if ( cgs.gameSounds[ parm ] ) {
+				trap->S_StartSound( NULL, ps->clientNum, CHAN_AUTO, cgs.gameSounds[ parm ] );
+			} else {
+				const char *s = CG_ConfigString( CS_SOUNDS + parm );
+				trap->S_StartSound( NULL, ps->clientNum, CHAN_AUTO, CG_CustomSound( ps->clientNum, s ) );
+			}
+		}
+	}
+}
+
+/*
 ===================
 CG_TransitionSnapshot
 
@@ -237,6 +280,10 @@ static void CG_TransitionSnapshot( void ) {
 		else if (cg_cameraFPS.integer >= CAMERA_MIN_FPS) {
 			cg.thisFrameTeleport = qfalse; // clear for interpolated player with new camera damping
 		}
+
+		// server-driven sounds are played from the snapshot so prediction
+		// replay can't clobber them (see CG_CheckServerSoundEvents)
+		CG_CheckServerSoundEvents( ps, ops );
 
 		// if we are not doing client side movement prediction for any
 		// reason, then the client events and view changes will be issued now


### PR DESCRIPTION
## Summary
- Server-injected `EV_GENERAL_SOUND` events ride the playerState event ring (`MAX_PS_EVENTS` = 2). Client prediction replay appends predicted events (footsteps, jumps) to the same ring and could overwrite a server sound before `CG_TransitionPlayerState` fired it — the local player never heard their own server-driven sounds unless `cg_nopredict` was set.
- Play `EV_GENERAL_SOUND` straight off the snapshot transition (`CG_CheckServerSoundEvents` in `cg_snapshot.c`), where the event sequence is authoritative.
- Skip `EV_GENERAL_SOUND` in `CG_CheckPlayerstateEvents` (bookkeeping preserved) so it cannot double-play.
- Sounds are started directly via `trap->S_StartSound` instead of routing through `CG_EntityEvent` with a faked entityState: the playerState carries no sound channel, and `saberEntityNum` would be misread as one — values 52–55 land on the `TRACK_CHANNEL` force-loop path and leak looping sounds into `centity_t`.

## Testing
- Builds clean (MSVC x86 Release).
- Needs verification against the repulse server-side branch: joining a server currently still drops after map load (suspected unrelated event-enum mismatch between this branch and the server mod — see review notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)