### PR TITLE
🦊 JA+ ledge grab: keep skeleton anim-driven + stop camera shake

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -3305,6 +3305,14 @@ static void CG_SetLerpFrameAnimation( centity_t *cent, clientInfo_t *ci, lerpFra
 		{
 			flags = BONE_ANIM_OVERRIDE_LOOP;
 		}
+		else if (cgs.serverMod == SVMOD_JAPLUS &&
+			(newAnimation == BOTH_LEDGE_LEFT || newAnimation == BOTH_LEDGE_RIGHT))
+		{ //JA+ ledge shimmy: authored as a half-second one-shot that freezes on its
+		  //last frame, so the hands stop moving unless the server's retrigger reaches
+		  //us at exactly the right time. Loop it client-side instead - the server
+		  //switches the anim number the moment we stop or change direction anyway.
+			flags = BONE_ANIM_OVERRIDE_LOOP;
+		}
 
 		if (animSpeed < 0)
 		{
@@ -3690,9 +3698,21 @@ static void CG_RunLerpFrame( centity_t *cent, clientInfo_t *ci, lerpFrame_t *lf,
 	}
 	else
 	{
+		qboolean flipRestart;
+
 		lf->lastForcedFrame = -1;
 
-		if ( (newAnimation != lf->animationNumber || cent->currentState.brokenLimbs != ci->brokenLimbs || lf->lastFlip != flipState || !lf->animation) || (CG_FirstAnimFrame(lf, torsoOnly, speedScale)) )
+		flipRestart = (qboolean)(lf->lastFlip != flipState);
+		if (flipRestart && newAnimation == lf->animationNumber &&
+			cgs.serverMod == SVMOD_JAPLUS &&
+			(newAnimation == BOTH_LEDGE_LEFT || newAnimation == BOTH_LEDGE_RIGHT))
+		{ //JA+ retriggers the ledge shimmy anims to keep them going; we loop them
+		  //instead (see CG_SetLerpFrameAnimation), so don't yank the loop back to
+		  //frame 0 on every retrigger.
+			flipRestart = qfalse;
+		}
+
+		if ( (newAnimation != lf->animationNumber || cent->currentState.brokenLimbs != ci->brokenLimbs || flipRestart || !lf->animation) || (CG_FirstAnimFrame(lf, torsoOnly, speedScale)) )
 		{
 			CG_SetLerpFrameAnimation( cent, ci, lf, newAnimation, speedScale, torsoOnly, flipState);
 		}

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -10810,6 +10810,20 @@ static void BG_G2ClientNeckAngles( void *ghoul2, int time, const vec3_t lookAngl
 	trap->G2API_SetBoneAngles(ghoul2, 0, "thoracic", thoracicAngles, BONE_ANGLES_POSTMULT, POSITIVE_X, NEGATIVE_Y, NEGATIVE_Z, 0, 0, time);
 }
 
+#ifdef _CGAME
+//JA+ servers hang us off ledges with these anims; the whole skeleton has to stay
+//anim-driven or the hands drift off the edge.
+static qboolean BG_InLedgeMove( int anim )
+{
+	if ( cgs.serverMod == SVMOD_JAPLUS
+		&& anim >= BOTH_LEDGE_GRAB && anim <= BOTH_LEDGE_MERCPULL )
+	{
+		return qtrue;
+	}
+	return qfalse;
+}
+#endif
+
 //rww - Finally decided to convert all this stuff to BG form.
 static void BG_G2ClientSpineAngles( void *ghoul2, int motionBolt, vec3_t cent_lerpOrigin, vec3_t cent_lerpAngles, entityState_t *cent,
 							int time, vec3_t viewAngles, int ciLegs, int ciTorso, const vec3_t angles, vec3_t thoracicAngles,
@@ -10820,6 +10834,17 @@ static void BG_G2ClientSpineAngles( void *ghoul2, int motionBolt, vec3_t cent_le
 	//*tPitchAngle = viewAngles[PITCH];
 	viewAngles[YAW] = AngleDelta( cent_lerpAngles[YAW], angles[YAW] );
 	//*tYawAngle = viewAngles[YAW];
+
+#ifdef _CGAME
+	if ( BG_InLedgeMove( cent->legsAnim ) || BG_InLedgeMove( cent->torsoAnim )
+		|| BG_InLedgeMove( ciLegs ) || BG_InLedgeMove( ciTorso ) )
+	{ //don't distribute view pitch/yaw up the spine while hanging from a ledge
+		VectorClear( thoracicAngles );
+		VectorClear( ulAngles );
+		VectorClear( llAngles );
+		return;
+	}
+#endif
 
 #if 1
 	if ( !BG_FlippingAnim( cent->legsAnim ) &&
@@ -11372,6 +11397,13 @@ void BG_G2PlayerAngles(void *ghoul2, int motionBolt, entityState_t *cent, int ti
 		eyeAngles[i] = AngleNormalize180( eyeAngles[i] );
 	}
 	AnglesSubtract( lookAngles, eyeAngles, lookAngles );
+
+#ifdef _CGAME
+	if ( BG_InLedgeMove( cent->legsAnim ) || BG_InLedgeMove( cent->torsoAnim ) )
+	{ //keep the head anim-driven too so it can't pivot into the wall
+		VectorClear( lookAngles );
+	}
+#endif
 
 	BG_UpdateLookAngles(lookTime, lastHeadAngles, time, lookAngles, lookSpeed, -50.0f, 50.0f, -70.0f, 70.0f, -30.0f, 30.0f);
 

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -12513,6 +12513,21 @@ void PmoveSingle (pmove_t *pmove) {
 			  //1 and not 0: gravity <= 0 flips PM_CheckJump into its zero-G push-off mode
 			  //(and divides by zero in PM_CrashLand), which sends the camera flying
 				pm->ps->gravity = 1;
+
+				//the ledge anims are server-driven with finite timers, and prediction
+				//runs ~a ping ahead: the moment the predicted torsoTimer hits zero,
+				//PM_Weapon stomps the torso with a weapon-ready pose until the next
+				//snapshot restores it, restarting the shimmy anim from frame 0 over
+				//and over. Keep the timers alive so prediction never ends the anim
+				//(same trick the BOTH_MEDITATE handling uses above).
+				if (pm->ps->legsTimer < 100)
+				{
+					pm->ps->legsTimer = 100;
+				}
+				if (pm->ps->torsoTimer < 100)
+				{
+					pm->ps->torsoTimer = 100;
+				}
 			}
 		}
 		else

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -12506,6 +12506,14 @@ void PmoveSingle (pmove_t *pmove) {
 		{
 			PM_SetPMViewAngle(pm->ps, pm->ps->viewangles, &pm->cmd);
 			stiffenedUp = qtrue;
+
+			if (pm->ps->legsAnim >= BOTH_LEDGE_GRAB && pm->ps->legsAnim <= BOTH_LEDGE_MERCPULL)
+			{ //the server owns our position on the ledge; predicting gravity just makes us
+			  //fall a little every frame and get snapped back each snapshot (camera shake).
+			  //1 and not 0: gravity <= 0 flips PM_CheckJump into its zero-G push-off mode
+			  //(and divides by zero in PM_CrashLand), which sends the camera flying
+				pm->ps->gravity = 1;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Three client-side fixes for hanging from ledges on JA+ servers (`BOTH_LEDGE_*` anims):

**1. Torso/head no longer follow the view while hanging**
The shared angle code distributes view pitch across the spine bones (`thoracic`/`upper_lumbar`/`lower_lumbar`) and head-tracks the view unconditionally. Looking up/down while hanging bent the torso, pulled the hands off the edge and pushed the head through walls. There is a long exclusion list for flips/rolls/knockdowns/special jumps, but the JA+ ledge anims were never on it. A new `BG_InLedgeMove()` check (cgame-only, gated on `SVMOD_JAPLUS`) keeps the whole skeleton anim-driven for the ledge anim range, so players on ledges render exactly as the animation was authored. Fixes it for the local player and everyone else you see.

**2. Camera no longer shakes while hanging still**
The JA+ server pins your origin on the ledge, but local prediction kept applying gravity: every predicted frame you sank a little, every snapshot yanked you back up - a constant small oscillation of the camera even when idle. Predicted gravity is now forced to 1 during the ledge anims. 1 and not 0, because `gravity <= 0` flips `PM_CheckJump` into its zero-G push-off mode (reachable while airborne, no upmove gate - it launches you at 2x jump velocity every frame) and `PM_CrashLand` divides by gravity. Gravity 1 keeps all special cases dormant while cutting predicted drift ~800x, below anything visible.

**3. The shimmy anim actually plays while moving along the ledge**
`BOTH_LEDGE_LEFT/RIGHT` are authored as half-second one-shots with no loop (10 frames @ 20fps, `loopFrames -1`), so the hand-over-hand motion froze on its last frame unless the server's retrigger toggle landed at exactly the right time - for the local player that signal has to survive the whole prediction pipeline, so shimmying often showed frozen hands. The client now owns the loop: the shimmy anims play with `BONE_ANIM_OVERRIDE_LOOP` on JA+ servers (the server switches the anim number the moment you stop or reverse, so transitions are unaffected), flip retriggers are ignored while the same shimmy anim continues (they cannot yank the loop back to frame 0 mid-cycle), and the predicted anim timers are floored during the ledge anims so `PM_Weapon` cannot decide the anim ended a ping early and stomp the torso with a weapon-ready pose (same trick the `BOTH_MEDITATE` handling uses).

All changes are `#ifdef _CGAME` and/or JA+-gated, so server code and other mods are untouched. Tested on a JA+ server: hands stay locked to the edge at any view pitch, camera is steady while hanging, the shimmy anim cycles smoothly the whole time you move, and drop/climb transitions behave normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)