### PR TITLE
fix for the plugin 0 for drainfx

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -11919,9 +11919,9 @@ skipTrail:
 		{//arc
 			//trap->FX_PlayEffectID( cgs.effects.forceLightningWide, efOrg, fxDir );
 			//trap->FX_PlayEntityEffectID(cgs.effects.forceDrainWide, efOrg, axis, cent->boltInfo, cent->currentState.number, -1, -1);
-			if (cg_drainFX.integer == 2)
+			if (cp_pluginDisable.integer & JAPRO_PLUGIN_NEWDRAINEFX) // No matter the cg_drainfx value, we use the japro fx if plugin is enabled
 				trap->FX_PlayEntityEffectID(cgs.effects.forceDrainWideJaPRO, efOrg, axis, -1, -1, -1, -1);
-			else if (cg_drainFX.integer == 1)
+			else if (cg_drainFX.integer == 1 && !(cp_pluginDisable.integer & JAPRO_PLUGIN_NEWDRAINEFX))
 				trap->FX_PlayEntityEffectID(cgs.effects.forceDrainWide, efOrg, axis, -1, -1, -1, -1);
 		}
 		else


### PR DESCRIPTION
no matter which value cg_drainfx has, if plugin 0 is enabled, we use the japro fx. If plugin 0 is off: cg_drainfx 1 = normal fx
cg_drainfx 0 = no fx