### PR TITLE
🦊 jp_empowerEffect: trim the empower glow

### DIFF
--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -2078,6 +2078,7 @@ typedef struct cgs_s {
 	// parsed from serverinfo
 	int				siegeTeamSwitch;
 	int				showDuelHealths;
+	int				empowerEffect;		// JoF - jp_empowerEffect: 0=full body, 1=arms only, 2=hands only
 	gametype_t		gametype;
 	int				debugMelee;
 	int				stepSlideFix;

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -5558,6 +5558,24 @@ static const char *cg_pushBoneNames[] =
 	NULL
 };
 
+// JoF - jp_empowerEffect 1: arms only (two per arm)
+static const char *cg_empowerArmBoneNames[] =
+{
+	"rhand",
+	"lhand",
+	"lradius",
+	"rradius",
+	NULL
+};
+
+// JoF - jp_empowerEffect 2: only the bolt nearest each hand
+static const char *cg_empowerHandBoneNames[] =
+{
+	"rhand",
+	"lhand",
+	NULL
+};
+
 void CG_ForceGripped( const vec3_t org, qboolean darkSide )
 {
 	localEntity_t	*ex;
@@ -5614,12 +5632,17 @@ void CG_ForceGripped( const vec3_t org, qboolean darkSide )
 	ex->refEntity.customShader = trap->R_RegisterShader( "gfx/effects/forcePush" );
 }
 
-static void CG_ForcePushBodyBlur( centity_t *cent )
+static void CG_ForcePushBodyBlurBones( centity_t *cent, const char **boneNames )
 {
 	vec3_t fxOrg;
 	mdxaBone_t	boltMatrix;
 	int bolt;
 	int i;
+
+	if (!boneNames || !boneNames[0])
+	{ //nothing to draw
+		return;
+	}
 
 	if (cent->localAnimIndex > 1)
 	{ //Sorry, the humanoid IS IN ANOTHER CASTLE.
@@ -5638,13 +5661,13 @@ static void CG_ForcePushBodyBlur( centity_t *cent )
 
 	assert(cent->ghoul2);
 
-	for (i = 0; cg_pushBoneNames[i]; i++)
+	for (i = 0; boneNames[i]; i++)
 	{ //go through all the bones we want to put a blur effect on
-		bolt = trap->G2API_AddBolt(cent->ghoul2, 0, cg_pushBoneNames[i]);
+		bolt = trap->G2API_AddBolt(cent->ghoul2, 0, boneNames[i]);
 
 		if (bolt == -1)
 		{
-			assert(!"You've got an invalid bone/bolt name in cg_pushBoneNames");
+			assert(!"You've got an invalid bone/bolt name in the blur bone list");
 			continue;
 		}
 
@@ -5654,6 +5677,33 @@ static void CG_ForcePushBodyBlur( centity_t *cent )
 		//standard effect, don't be refractive (for now)
 		CG_ForcePushBlur(fxOrg, NULL);
 	}
+}
+
+static void CG_ForcePushBodyBlur( centity_t *cent )
+{ //being force-pushed: always the full bone set, unaffected by jp_empowerEffect
+	CG_ForcePushBodyBlurBones(cent, cg_pushBoneNames);
+}
+
+// JoF - empower glow. Bone set selected by the server's jp_empowerEffect.
+static void CG_EmpowerBodyBlur( centity_t *cent )
+{
+	const char **boneNames;
+
+	switch (cgs.empowerEffect)
+	{
+	case 1:
+		boneNames = cg_empowerArmBoneNames;
+		break;
+	case 2:
+		boneNames = cg_empowerHandBoneNames;
+		break;
+	case 0:
+	default:
+		boneNames = cg_pushBoneNames;
+		break;
+	}
+
+	CG_ForcePushBodyBlurBones(cent, boneNames);
 }
 
 static int cg_forceAnimFxNextTime[MAX_GENTITIES];
@@ -12084,11 +12134,21 @@ skipTrail:
 				}
 
 	//fullbody push effect - don't render it for anyone while the local player is zoomed (keeps the scope view clean)
+	//JoF - empower sets EF_BODYPUSH *and* EF_EMPOWERED (so old clients still see a
+	//glow). Check EF_EMPOWERED first and draw the jp_empowerEffect bone set; otherwise
+	//an empowered player would draw both the trimmed set and the full push set.
 	if ((cent->currentState.eFlags & EF_BODYPUSH) &&
 		forceFXVisible &&
 		!((cg.predictedPlayerState.zoomMode || !cg.renderingThirdPerson) && cent->currentState.number == cg.predictedPlayerState.clientNum))
 	{
-		CG_ForcePushBodyBlur(cent);
+		if (cent->currentState.eFlags & EF_EMPOWERED)
+		{
+			CG_EmpowerBodyBlur(cent);
+		}
+		else
+		{
+			CG_ForcePushBodyBlur(cent);
+		}
 	}
 
 

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -196,6 +196,8 @@ void CG_ParseServerinfo( void ) {
 
 	cgs.showDuelHealths = atoi( Info_ValueForKey( info, "g_showDuelHealths" ) );
 
+	cgs.empowerEffect = atoi( Info_ValueForKey( info, "jp_empowerEffect" ) );	// JoF
+
 	cgs.gametype = atoi( Info_ValueForKey( info, "g_gametype" ) );
 	trap->Cvar_Set("g_gametype", va("%i", cgs.gametype));
 	cgs.needpass = atoi( Info_ValueForKey( info, "g_needpass" ) );

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -766,7 +766,7 @@ typedef enum {
 #define	EF_NOT_USED_6			(1<<15)		// not used
 #define	EF_GRAPPLE_SWING		(1<<16)		// not used
 #define	EF_BOBAFIRE				(1<<17)		
-#define	EF_NOT_USED_4			(1<<18)		// not used
+#define	EF_EMPOWERED			(1<<18)		// JoF - player is amempowered (set alongside EF_BODYPUSH)
 
 #define	EF_BODYPUSH				(1<<19)		//rww - claiming this for fullbody push effect
 


### PR DESCRIPTION
## What

Adds `jp_empowerEffect`, a server cvar (`CVAR_SERVERINFO`) that lets admins choose a lighter body-glow for empowered players without changing what force push looks like.

An empowered player (`/amempower`) lights up with the same 8-orb body blur as someone being force-pushed, because JA+ reused the `EF_BODYPUSH` eFlag for both — they are literally the same clientside code path (`CG_ForcePushBodyBlur`). Trimming the shared bone list would change force push for everyone, so the client needs a way to tell the two apart.

## How

The server sets a **new** `EF_EMPOWERED` (bit 18, was `EF_NOT_USED_4`) *alongside* `EF_BODYPUSH` while empowered, and ships `jp_empowerEffect` in serverinfo. The client checks `EF_EMPOWERED` first and draws a bone set chosen by the cvar; a genuine push (no `EF_EMPOWERED`) still draws the full set.

| Value | Bones drawn |
|:---:|---|
| `0` (default) | all 8 — identical to today |
| `1` | arms only: `rhand`, `lhand`, `lradius`, `rradius` |
| `2` | hands only: `rhand`, `lhand` |

The two branches are mutually exclusive (`EF_EMPOWERED` wins, push is the `else`), so the effects never stack.

## Backwards compatible

The server sets **both** flags rather than swapping one for the other. Old/vanilla clients only understand `EF_BODYPUSH`, so they keep rendering the full 8 orbs and silently ignore the cvar — nothing breaks, no coordinated rollout. Patched clients see `EF_EMPOWERED` and honour the cvar. `eFlags` is already networked, so there is no netcode change.

## Files

- `codemp/game/bg_public.h` — `EF_EMPOWERED (1<<18)`
- `codemp/cgame/cg_local.h` — `cgs.empowerEffect`
- `codemp/cgame/cg_servercmds.c` — parse `jp_empowerEffect` from serverinfo
- `codemp/cgame/cg_players.c` — two empower bone lists; `CG_ForcePushBodyBlur` factored into `CG_ForcePushBodyBlurBones(cent, boneNames)`; new `CG_EmpowerBodyBlur`; `CG_Player` branches on `EF_EMPOWERED` first

## Notes

- Requires the paired server-side patch that sets `EF_EMPOWERED`; the client change is inert-but-harmless without it.
- `EF_EMPOWERED` must stay `1<<18` — the server patch hardcodes that bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
