### PR TITLE
Add JAPLUS tab to controls menu

### DIFF
--- a/assets/japro/ui/jamp/controls.menu
+++ b/assets/japro/ui/jamp/controls.menu
@@ -17,9 +17,10 @@
 		descColor				1 .682 0 .8
 		descAlignment			ITEM_ALIGN_CENTER		
 
-		onOpen 
+		onOpen
 		{
 			uiScript 		loadControls;
+			uiScript		refreshModTabs;
 
 			show			setup_background ;
 			show 			movecontrols ;
@@ -908,10 +909,10 @@
 		}
 
 		// japro  button
-		itemDef 
+		itemDef
 		{
 			name				japrocontrolbutton_glow
-			group				mods
+			group				japrobutton
 			style				WINDOW_STYLE_SHADER
 			rect				80 353 180 24
 			background			"gfx/menus/menu_blendbox2"			// Frame around button
@@ -923,7 +924,7 @@
 		itemDef 
 		{
 			name				japrocontrolbutton
-			group				none
+			group				japrobutton
 			text				JAPRO
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
@@ -1042,7 +1043,7 @@
 		itemDef
 		{
 			name				japluscontrolbutton_glow
-			group				mods
+			group				japlusbutton
 			style				WINDOW_STYLE_SHADER
 			rect				80 401 180 24
 			background			"gfx/menus/menu_blendbox2"			// Frame around button
@@ -1054,7 +1055,7 @@
 		itemDef
 		{
 			name				japluscontrolbutton
-			group				none
+			group				japlusbutton
 			text				JAPLUS
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
@@ -4207,7 +4208,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Balanced Force Duel:"
+			text				"Balanced Force Duel:"
 			cvar				"engage_balancedforceduel"
 			rect				260 244 340 14
 			textalign			ITEM_ALIGN_RIGHT
@@ -4239,7 +4240,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Dash:"
+			text				"Force Dash:"
 			cvar				"force_dash"
 			rect				260 259 340 14
 			textalign			ITEM_ALIGN_RIGHT
@@ -4271,7 +4272,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Stasis:"
+			text				"Force Stasis:"
 			cvar				"+force_stasis"
 			rect				260 274 340 14
 			textalign			ITEM_ALIGN_RIGHT
@@ -4303,7 +4304,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Repulse:"
+			text				"Force Repulse:"
 			cvar				"force_repulse"
 			rect				260 289 340 14
 			textalign			ITEM_ALIGN_RIGHT

--- a/assets/japro/ui/jamp/controls.menu
+++ b/assets/japro/ui/jamp/controls.menu
@@ -32,6 +32,7 @@
 			hide			othercontrols ;
 			hide			japrocontrols ;
 			hide			radialmenucontrols ;
+			hide			japluscontrols ;
 			setitemcolor		movementcontrolbutton 		forecolor 1 1 1 1 ;
 			setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 			setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -496,6 +497,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -505,9 +507,10 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
-		
+
 
 		// attack  button
 		itemDef 
@@ -561,6 +564,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -570,6 +574,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -625,6 +630,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 1 1 1 ;
@@ -634,6 +640,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -689,6 +696,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -698,6 +706,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -752,6 +761,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -761,6 +771,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -816,6 +827,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -825,6 +837,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -880,6 +893,7 @@
 				show			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -889,9 +903,10 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		japrocontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
-		
+
 		// japro  button
 		itemDef 
 		{
@@ -909,7 +924,7 @@
 		{
 			name				japrocontrolbutton
 			group				none
-			text				japro
+			text				JAPRO
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
 			rect				80 353 170 24
@@ -923,16 +938,16 @@
 			visible			1
 			descText			"Configure your jaPRO controls."
 
-			mouseEnter 
-			{ 
+			mouseEnter
+			{
 				show			japrocontrolbutton_glow
 			}
-			mouseExit 
-			{ 
+			mouseExit
+			{
 				hide			japrocontrolbutton_glow
-			}	  	  
-			action 
-			{ 
+			}
+			action
+			{
 				play			"sound/interface/button1.wav" ;
 				show			setup_background ;
 				hide			movecontrols ;
@@ -944,6 +959,7 @@
 				hide			othercontrols ;
 				show			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -953,10 +969,11 @@
 				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 1 1 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 		// radialmenu  button
-		itemDef 
+		itemDef
 		{
 			name				radialmenubutton_glow
 			group				mods
@@ -967,8 +984,8 @@
 			visible				0
 			decoration
 		}
-		
-		itemDef 
+
+		itemDef
 		{
 			name				radialmenubutton
 			group				none
@@ -986,16 +1003,16 @@
 			visible			1
 			descText			"Configure the Radial Menu binds."
 
-			mouseEnter 
-			{ 
+			mouseEnter
+			{
 				show			radialmenubutton_glow
 			}
-			mouseExit 
-			{ 
+			mouseExit
+			{
 				hide			radialmenubutton_glow
-			}	  	  
-			action 
-			{ 
+			}
+			action
+			{
 				play			"sound/interface/button1.wav" ;
 				show			setup_background ;
 				hide			movecontrols ;
@@ -1007,6 +1024,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				show			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -1016,10 +1034,77 @@
 				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 1 1 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
-		itemDef 
+		// japlus  button
+		itemDef
+		{
+			name				japluscontrolbutton_glow
+			group				mods
+			style				WINDOW_STYLE_SHADER
+			rect				80 401 180 24
+			background			"gfx/menus/menu_blendbox2"			// Frame around button
+			forecolor			1 1 1 1
+			visible				0
+			decoration
+		}
+
+		itemDef
+		{
+			name				japluscontrolbutton
+			group				none
+			text				JAPLUS
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				80 401 170 24
+			font				3
+			textscale			0.9
+			textalignx			160
+			textaligny			2
+			textalign			ITEM_ALIGN_RIGHT
+			textstyle			0
+			forecolor			1 .682 0 1
+			visible			1
+			descText			"Configure your JA+ controls."
+
+			mouseEnter
+			{
+				show			japluscontrolbutton_glow
+			}
+			mouseExit
+			{
+				hide			japluscontrolbutton_glow
+			}
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+				show			setup_background ;
+				hide			movecontrols ;
+				hide 			attackcontrols ;
+				hide 			weaponcontrols ;
+				hide			forcecontrols ;
+				hide			forcecontrols2 ;
+				hide			joycontrols ;
+				hide			othercontrols ;
+				hide			japrocontrols ;
+				hide			radialmenucontrols ;
+				show			japluscontrols ;
+				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		forcecontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		forcecontrolbutton2 		forecolor 1 .682 0 1 ;
+				setitemcolor		mousejoystickcontrolbutton 	forecolor 1 .682 0 1 ;
+				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 1 1 1 ;
+			}
+		}
+
+		itemDef
 		{
 			name				setup_background
 			group				none
@@ -3987,10 +4072,271 @@
 
 //----------------------------------------------------------------------------------------------
 //
+//	JAPLUS BINDING
+//
+//----------------------------------------------------------------------------------------------
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Grapple Hook (auto release):"
+			cvar				"+grapple"
+			rect				260 188 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Fire the grapple hook; automatically releases on JA+ servers."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight1
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight1
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Grapple Hook (manual release):"
+			cvar				"+button12"
+			rect				260 202 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Fire the grapple hook; you control when it releases."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight2
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight2
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Jetpack:"
+			cvar				"+button12"
+			rect				260 216 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Gives Jetpack"
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight3
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight3
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Full Force Duel:"
+			cvar				"engage_fullforceduel"
+			rect				260 230 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Challenge an enemy to a private full force duel, or accept another's challenge."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight4
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight4
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Balanced Force Duel:"
+			cvar				"engage_balancedforceduel"
+			rect				260 244 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Challenge an enemy to a private balanced force duel, or accept another's challenge. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight5
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight5
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Dash:"
+			cvar				"force_dash"
+			rect				260 259 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Dash using the JA+ force dash ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight6
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight6
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Stasis:"
+			cvar				"+force_stasis"
+			rect				260 274 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Uses the JA+ force stasis ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight7
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight7
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Repulse:"
+			cvar				"force_repulse"
+			rect				260 289 340 14
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			174
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Uses the JA+ force repulse ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight8
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight8
+				hide			keybindstatus
+			}
+		}
+
+//----------------------------------------------------------------------------------------------
+//
 //	JAPRO BINDING
 //
 //----------------------------------------------------------------------------------------------
-		itemDef 
+		itemDef
 		{
 			group				japrocontrols
 			type				ITEM_TYPE_BIND

--- a/assets/japro/ui/jamp/ingame_controls.menu
+++ b/assets/japro/ui/jamp/ingame_controls.menu
@@ -32,9 +32,10 @@
 
 		onopen 
 		{ 
-			hide				grpControls ; 
-			show				look ; 
-			uiScript			loadControls 
+			hide				grpControls ;
+			show				look ;
+			uiScript			loadControls
+			uiScript			refreshModTabs
 
 			show			setup_background ;
 			show			movecontrols ;
@@ -556,7 +557,7 @@
 		itemDef 
 		{
 			name				japrocontrolbutton_glow
-			group				mods
+			group				japrobutton
 			style				WINDOW_STYLE_SHADER
 			rect				20 253 185 30
 			background			"gfx/menus/menu_blendbox2"			// Frame around button
@@ -568,7 +569,7 @@
 		itemDef 
 		{
 			name				japrocontrolbutton
-			group				none
+			group				japrobutton
 			text				JAPRO
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
@@ -688,7 +689,7 @@
 		itemDef
 		{
 			name				japluscontrolbutton_glow
-			group				mods
+			group				japlusbutton
 			style				WINDOW_STYLE_SHADER
 			rect				20 313 185 30
 			background			"gfx/menus/menu_blendbox2"			// Frame around button
@@ -700,7 +701,7 @@
 		itemDef
 		{
 			name				japluscontrolbutton
-			group				none
+			group				japlusbutton
 			text				JAPLUS
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
@@ -3972,7 +3973,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Balanced Force Duel:"
+			text				"Balanced Force Duel:"
 			cvar				"engage_balancedforceduel"
 			rect				220 121 300 20
 			textalign			ITEM_ALIGN_RIGHT
@@ -4004,7 +4005,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Dash:"
+			text				"Force Dash:"
 			cvar				"force_dash"
 			rect				220 141 300 20
 			textalign			ITEM_ALIGN_RIGHT
@@ -4036,7 +4037,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Stasis:"
+			text				"Force Stasis:"
 			cvar				"+force_stasis"
 			rect				220 161 300 20
 			textalign			ITEM_ALIGN_RIGHT
@@ -4068,7 +4069,7 @@
 		{
 			group				japluscontrols
 			type				ITEM_TYPE_BIND
-			text				"JoF Force Repulse:"
+			text				"Force Repulse:"
 			cvar				"force_repulse"
 			rect				220 181 300 20
 			textalign			ITEM_ALIGN_RIGHT

--- a/assets/japro/ui/jamp/ingame_controls.menu
+++ b/assets/japro/ui/jamp/ingame_controls.menu
@@ -8,12 +8,12 @@
 		visible					0
 		fullscreen				0
 		outOfBoundsClick									// this closes the window if it gets a click out of the rectangle
-		rect					45 35 550 335
+		rect					45 35 550 365
 		focusColor				1 1 1 1								// Focus color for text and items
 		style					1
 		border					1
 		descX					305
-		descY					360
+		descY					390
 		descScale				1
 		descColor				1 .682 0 .8					// Focus color for text and items
 		descAlignment				ITEM_ALIGN_CENTER		
@@ -46,6 +46,7 @@
 			hide			othercontrols ;
 			hide			japrocontrols ;
 			hide			radialmenucontrols ;
+			hide			japluscontrols ;
 			setitemcolor		movementcontrolbutton 		forecolor 1 1 1 1 ;
 			setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1
 			setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -63,7 +64,7 @@
 			name				background_pic
 			group				none
 			style				WINDOW_STYLE_SHADER
-			rect				0 0 550 345
+			rect				0 0 550 365
 			background			"gfx/menus/menu_box_ingame"
 			forecolor			1 1 1 1
 			visible				1
@@ -135,13 +136,14 @@
 				show			setup_background ;
 				show			movecontrols ;
 				hide 			attackcontrols ;
-				hide 			weaponcontrols ;	
+				hide 			weaponcontrols ;
 				hide			forcecontrols ;
 				hide			forcecontrols2 ;
 				hide			joycontrols ;
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -151,6 +153,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -199,13 +202,14 @@
 				show			setup_background ;
 				hide			movecontrols ;
 				show 			attackcontrols ;
-				hide 			weaponcontrols ;	
+				hide 			weaponcontrols ;
 				hide			forcecontrols ;
 				hide			forcecontrols2 ;
 				hide			joycontrols ;
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -215,6 +219,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -263,13 +268,14 @@
 				show			setup_background ;
 				hide			movecontrols ;
 				hide 			attackcontrols ;
-				show 			weaponcontrols ;	
+				show 			weaponcontrols ;
 				hide			forcecontrols ;
 				hide			forcecontrols2 ;
 				hide			joycontrols ;
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 1 1 1 ;
@@ -279,6 +285,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -334,6 +341,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -343,6 +351,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -397,6 +406,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -406,6 +416,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -461,6 +472,7 @@
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -470,6 +482,7 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
 
@@ -525,6 +538,7 @@
 				show			othercontrols ;
 				hide			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -534,9 +548,10 @@
 				setitemcolor		othercontrolbutton 		forecolor 1 1 1 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
-		
+
 		// japro button
 		itemDef 
 		{
@@ -554,7 +569,7 @@
 		{
 			name				japrocontrolbutton
 			group				none
-			text				japro
+			text				JAPRO
 			type				ITEM_TYPE_BUTTON
 			style				WINDOW_STYLE_EMPTY
 			rect				20 253 170 30
@@ -568,27 +583,28 @@
 			visible				1
 			descText			"Configure your jaPRO controls."
 
-			mouseEnter 
-			{ 
+			mouseEnter
+			{
 				show			japrocontrolbutton_glow
 			}
-			mouseExit 
-			{ 
+			mouseExit
+			{
 				hide			japrocontrolbutton_glow
-			}	  	  
-			action 
-			{ 
+			}
+			action
+			{
 				play			"sound/interface/button1.wav" ;
 				show			setup_background ;
 				hide			movecontrols ;
 				hide 			attackcontrols ;
-				hide 			weaponcontrols ;	
+				hide 			weaponcontrols ;
 				hide			forcecontrols ;
 				hide			forcecontrols2 ;
 				hide			joycontrols ;
 				hide			othercontrols ;
 				show			japrocontrols ;
 				hide			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -598,11 +614,12 @@
 				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 1 1 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
-		
+
 		// radialmenu button
-		itemDef 
+		itemDef
 		{
 			name				radialmenubutton_glow
 			group				mods
@@ -614,7 +631,7 @@
 			decoration
 		}
 
-		itemDef 
+		itemDef
 		{
 			name				radialmenubutton
 			group				none
@@ -632,27 +649,28 @@
 			visible				1
 			descText			"Configure the Radial Menu binds."
 
-			mouseEnter 
-			{ 
+			mouseEnter
+			{
 				show			radialmenubutton_glow
 			}
-			mouseExit 
-			{ 
+			mouseExit
+			{
 				hide			radialmenubutton_glow
-			}	  	  
-			action 
-			{ 
+			}
+			action
+			{
 				play			"sound/interface/button1.wav" ;
 				show			setup_background ;
 				hide			movecontrols ;
 				hide 			attackcontrols ;
-				hide 			weaponcontrols ;	
+				hide 			weaponcontrols ;
 				hide			forcecontrols ;
 				hide			forcecontrols2 ;
 				hide			joycontrols ;
 				hide			othercontrols ;
 				hide			japrocontrols ;
 				show			radialmenucontrols ;
+				hide			japluscontrols ;
 				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
 				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
@@ -662,9 +680,77 @@
 				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
 				setitemcolor		radialmenubutton 			forecolor 1 1 1 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 .682 0 1 ;
 			}
 		}
-		itemDef 
+
+		// japlus button
+		itemDef
+		{
+			name				japluscontrolbutton_glow
+			group				mods
+			style				WINDOW_STYLE_SHADER
+			rect				20 313 185 30
+			background			"gfx/menus/menu_blendbox2"			// Frame around button
+			forecolor			1 1 1 1
+			visible				0
+			decoration
+		}
+
+		itemDef
+		{
+			name				japluscontrolbutton
+			group				none
+			text				JAPLUS
+			type				ITEM_TYPE_BUTTON
+			style				WINDOW_STYLE_EMPTY
+			rect				20 313 170 30
+			font				3
+			textscale			0.8
+			textalignx			170
+			textaligny			5
+			textalign			ITEM_ALIGN_RIGHT
+			textstyle			3
+			forecolor			0.65 0.65 1 1
+			visible				1
+			descText			"Configure your JA+ controls."
+
+			mouseEnter
+			{
+				show			japluscontrolbutton_glow
+			}
+			mouseExit
+			{
+				hide			japluscontrolbutton_glow
+			}
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+				show			setup_background ;
+				hide			movecontrols ;
+				hide 			attackcontrols ;
+				hide 			weaponcontrols ;
+				hide			forcecontrols ;
+				hide			forcecontrols2 ;
+				hide			joycontrols ;
+				hide			othercontrols ;
+				hide			japrocontrols ;
+				hide			radialmenucontrols ;
+				show			japluscontrols ;
+				setitemcolor		movementcontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		attackcontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		weaponscontrolbutton 		forecolor 1 .682 0 1 ;
+				setitemcolor		forcecontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		forcecontrolbutton2 		forecolor 1 .682 0 1 ;
+				setitemcolor		mousejoystickcontrolbutton 	forecolor 1 .682 0 1 ;
+				setitemcolor		othercontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japrocontrolbutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		radialmenubutton 			forecolor 1 .682 0 1 ;
+				setitemcolor		japluscontrolbutton 		forecolor 1 1 1 1 ;
+			}
+		}
+
+		itemDef
 		{
 			name				setup_background
 			group				none
@@ -3751,10 +3837,271 @@
 		
 //----------------------------------------------------------------------------------------------
 //
+//	JAPLUS BINDING
+//
+//----------------------------------------------------------------------------------------------
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Grapple Hook (auto release):"
+			cvar				"+grapple"
+			rect				220 41 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Fire the grapple hook; automatically releases on JA+ servers."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight1
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight1
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Grapple Hook (manual release):"
+			cvar				"+button12"
+			rect				220 61 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Fire the grapple hook; you control when it releases."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight2
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight2
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Jetpack:"
+			cvar				"+button14"
+			rect				220 81 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Gives Jetpack"
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight3
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight3
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"Full Force Duel:"
+			cvar				"engage_fullforceduel"
+			rect				220 101 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Challenge an enemy to a private full force duel, or accept another's challenge."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight4
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight4
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Balanced Force Duel:"
+			cvar				"engage_balancedforceduel"
+			rect				220 121 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Challenge an enemy to a private balanced force duel, or accept another's challenge. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight5
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight5
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Dash:"
+			cvar				"force_dash"
+			rect				220 141 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Dash using the JA+ force dash ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight6
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight6
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Stasis:"
+			cvar				"+force_stasis"
+			rect				220 161 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Uses the JA+ force stasis ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight7
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight7
+				hide			keybindstatus
+			}
+		}
+
+		itemDef
+		{
+			group				japluscontrols
+			type				ITEM_TYPE_BIND
+			text				"JoF Force Repulse:"
+			cvar				"force_repulse"
+			rect				220 181 300 20
+			textalign			ITEM_ALIGN_RIGHT
+			textalignx			151
+			textaligny			0
+			font				4
+			textscale			1
+			forecolor			.615 .615 .956 1
+			visible				0
+			descText			"Uses the JA+ force repulse ability. JA+ servers only."
+			action
+			{
+				play			"sound/interface/button1.wav" ;
+			}
+
+			mouseenter
+			{
+				show			highlight8
+				show			keybindstatus
+			}
+			mouseexit
+			{
+				hide			highlight8
+				hide			keybindstatus
+			}
+		}
+
+//----------------------------------------------------------------------------------------------
+//
 //	JAPRO BINDING
 //
 //----------------------------------------------------------------------------------------------
-		itemDef 
+		itemDef
 		{
 			group				japrocontrols
 			type				ITEM_TYPE_BIND

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -679,6 +679,7 @@ void UI_UpdateCurrentServerInfo(void) { //parses server info to contextually hid
 	char *value = NULL;
 
 	trap->Cvar_Set("ui_isJAPro", "0");
+	trap->Cvar_Set("ui_isJAPlus", "0");
 	trap->Cvar_Set("ui_raceMode", "0");
 	trap->Cvar_Set("ui_allowRegistration", "0");
 	trap->Cvar_Set("ui_allowSaberSwitch", "0");
@@ -696,6 +697,7 @@ void UI_UpdateCurrentServerInfo(void) { //parses server info to contextually hid
 	if (!Q_stricmpn(value, "JA+ Mod", 7) || !Q_stricmpn(value, "^4U^3A^5Galaxy", 14) || !Q_stricmpn(value, "AbyssMod", 8))
 	{
 		trap->Cvar_Set("ui_allowSaberSwitch", "1");
+		trap->Cvar_Set("ui_isJAPlus", "1");
 	}
 	else if (!Q_stricmpn(value, "japro", 5)) {
 		int jcinfo2;
@@ -8249,6 +8251,17 @@ static void UI_RunMenuScript(char **args)
 			Controls_SetConfig();
 		} else if (Q_stricmp(name, "loadControls") == 0) {
 			Controls_GetConfig();
+		} else if (Q_stricmp(name, "refreshModTabs") == 0) {
+			//JAPRO - show the JAPLUS controls tab only when connected to a detected
+			//JA+ server, and JAPRO otherwise (including disconnected/main menu).
+			//ui_isJAPlus/ui_isJAPro are refreshed by UI_UpdateCurrentServerInfo()
+			//on the relevant menu transitions.
+			menuDef_t *menu = Menu_GetFocused();
+			if (menu) {
+				qboolean isJaPlus = ui_isJAPlus.integer ? qtrue : qfalse;
+				Menu_ShowGroup(menu, "japlusbutton", isJaPlus);
+				Menu_ShowGroup(menu, "japrobutton", isJaPlus ? qfalse : qtrue);
+			}
 		} else if (Q_stricmp(name, "clearError") == 0) {
 			trap->Cvar_Set("com_errorMessage", "");
 		} else if (Q_stricmp(name, "loadGameInfo") == 0) {

--- a/codemp/ui/ui_xcvar.h
+++ b/codemp/ui/ui_xcvar.h
@@ -156,6 +156,7 @@ XCVAR_DEF( ui_username,						"",						NULL,				CVAR_ARCHIVE|CVAR_INTERNAL|CVAR_N
 XCVAR_DEF( ui_password,						"",						NULL,				CVAR_ARCHIVE|CVAR_INTERNAL|CVAR_NORESTART )
 XCVAR_DEF( ui_vgs,							"1",					NULL,				CVAR_ARCHIVE )
 XCVAR_DEF( ui_isJAPro,						"0",					NULL,				CVAR_INTERNAL|CVAR_ROM )
+XCVAR_DEF( ui_isJAPlus,						"0",					NULL,				CVAR_INTERNAL|CVAR_ROM )
 XCVAR_DEF( ui_allowSaberSwitch,				"0",					NULL,				CVAR_INTERNAL|CVAR_ROM )
 XCVAR_DEF( ui_RGBSkin,						"0",					NULL,				CVAR_INTERNAL|CVAR_ROM )
 XCVAR_DEF( cg_strafeHelper,					"3008",					NULL,				CVAR_ARCHIVE_ND )


### PR DESCRIPTION
Adds a JAPLUS button alongside the existing JAPRO tab in both the Setup > Controls screen and the in-game ESC controls panel, following the same top-level button pattern already used for Force Powers 1/2.

JAPLUS lists: Grapple Hook (auto release), Grapple Hook (manual release), Jetpack, and Full Force Duel, plus JoF-prefixed additions (JoF Balanced Force Duel, JoF Force Dash, JoF Force Stasis, JoF Force Repulse) that map to JA+ mod commands not implemented by jaPRO's own server code. All rows are always visible/bindable regardless of server type.