### PR TITLE
Implemented a clean up for .tmp pk3 files during failed/aborted ingame download

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -969,6 +969,22 @@ void CL_Disconnect( qboolean showMainMenu ) {
 		FS_FCloseFile( clc.download );
 		clc.download = 0;
 	}
+
+	// Remove any incomplete download .tmp file left behind.
+	if (*clc.downloadTempName) {
+		char* ospath;
+		//maybe hacky but engine requires os filesystem paths for fs_remove
+		ospath = FS_BuildOSPath(
+			Cvar_VariableString("fs_homepath"),
+			clc.downloadTempName,
+			""
+		);
+
+		ospath[strlen(ospath) - 1] = '\0';
+		Com_Printf("Removing: %s\n", ospath); //just for debug purposes, delete if neccesary.
+		FS_Remove(ospath);
+	}
+
 	*clc.downloadTempName = *clc.downloadName = 0;
 	Cvar_Set( "cl_downloadName", "" );
 


### PR DESCRIPTION
Removes any downloaded .tmp files left behind after either pressing esc, crash or server disconnect.