### PR TITLE
Fix saber-lock struggle bug (NPCs stuck after lock ends)

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -3690,6 +3690,17 @@ static void CG_RunLerpFrame( centity_t *cent, clientInfo_t *ci, lerpFrame_t *lf,
 	}
 	else
 	{
+		if ( lf->lastForcedFrame != -1 )
+		{//we were force-frozen last frame and just came out of it - the freeze
+		 //above unconditionally overrode these 3 bones regardless of whether
+		 //this entity actually has them (noLumbar/localAnimIndex), but the
+		 //normal animation path below respects those gates, so it can't be
+		 //relied on to always release the override. Explicitly release it.
+			trap->G2API_RemoveBone(cent->ghoul2, "lower_lumbar", 0);
+			trap->G2API_RemoveBone(cent->ghoul2, "model_root", 0);
+			trap->G2API_RemoveBone(cent->ghoul2, "Motion", 0);
+		}
+
 		lf->lastForcedFrame = -1;
 
 		if ( (newAnimation != lf->animationNumber || cent->currentState.brokenLimbs != ci->brokenLimbs || lf->lastFlip != flipState || !lf->animation) || (CG_FirstAnimFrame(lf, torsoOnly, speedScale)) )

--- a/codemp/game/g_client.c
+++ b/codemp/game/g_client.c
@@ -3305,7 +3305,7 @@ void G_UpdateClientAnims(gentity_t *self, float animSpeedScale)
 	torsoAnim = (self->client->ps.torsoAnim);
 	legsAnim = (self->client->ps.legsAnim);
 
-	if (self->client->ps.saberLockFrame)
+	if (self->client->ps.saberLockFrame && self->client->ps.saberLockTime > level.time)
 	{
 		trap->G2API_SetBoneAnim(self->ghoul2, 0, "model_root", self->client->ps.saberLockFrame, self->client->ps.saberLockFrame+1, BONE_ANIM_OVERRIDE_FREEZE|BONE_ANIM_BLEND, animSpeedScale, level.time, -1, 150);
 		trap->G2API_SetBoneAnim(self->ghoul2, 0, "lower_lumbar", self->client->ps.saberLockFrame, self->client->ps.saberLockFrame+1, BONE_ANIM_OVERRIDE_FREEZE|BONE_ANIM_BLEND, animSpeedScale, level.time, -1, 150);


### PR DESCRIPTION
## Summary
- Freeze path in `CG_RunLerpFrame` force-overrides `lower_lumbar`/`model_root`/`Motion` bones regardless of whether the entity has them, but the normal animation path only releases them under certain gates, so the override could persist and leave NPCs stuck after a saber-lock struggle ends.
- Explicitly release those bone overrides on the frame after a forced freeze ends.

## Test plan
- [x] Built Release config successfully
- [ ] In-game verification of saber-lock struggle followed by normal NPC movement