### PR TITLE
fix: raise the macos open file limit on startup

### DIFF
--- a/codemp/qcommon/net_ip.cpp
+++ b/codemp/qcommon/net_ip.cpp
@@ -1050,6 +1050,15 @@ void NET_Sleep( int msec ) {
 
 	FD_ZERO(&fdset);
 	if (ip_socket != INVALID_SOCKET) {
+#ifndef _WIN32
+		// on unix fd_set is a fixed size bitmask indexed by descriptor number,
+		// so a socket that landed above FD_SETSIZE (possible now that we raise
+		// RLIMIT_NOFILE at startup) cannot be waited on without corrupting it
+		if (ip_socket >= FD_SETSIZE) {
+			Sys_Sleep(msec);
+			return;
+		}
+#endif
 		FD_SET(ip_socket, &fdset); // network socket
 		highestfd = ip_socket;
 	}

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -28,10 +28,15 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/resource.h>
 #include <pwd.h>
 #include <libgen.h>
 #include <sched.h>
 #include <signal.h>
+
+#ifdef MACOS_X
+#include <sys/sysctl.h>
+#endif
 
 #include "qcommon/qcommon.h"
 #include "qcommon/q_shared.h"
@@ -42,9 +47,68 @@ qboolean stdinIsATTY = qfalse;
 // Used to determine where to store user-specific files
 static char homePath[ MAX_OSPATH ] = { 0 };
 
+// how many descriptors we would like to have available; every pk3 in the search
+// path holds one open for the lifetime of the process, on top of the handles
+// handed out by the filesystem, sockets and loaded libraries
+#define SYS_WANTED_OPEN_FILES	8192
+
+/*
+==================
+Sys_RaiseOpenFileLimit
+
+macOS ships a soft RLIMIT_NOFILE of 256, which an asset heavy install runs out
+of while it is still opening pk3s. The hard limit is far higher, so raise the
+soft limit towards it at startup.
+==================
+*/
+static void Sys_RaiseOpenFileLimit( void )
+{
+	struct rlimit limit;
+
+	if ( getrlimit( RLIMIT_NOFILE, &limit ) == -1 )
+		return;
+
+	const rlim_t original = limit.rlim_cur;
+	rlim_t wanted = SYS_WANTED_OPEN_FILES;
+
+	if ( limit.rlim_max != RLIM_INFINITY && wanted > limit.rlim_max )
+		wanted = limit.rlim_max;
+
+#ifdef MACOS_X
+	// Darwin reports an unlimited hard limit but refuses any soft limit above
+	// kern.maxfilesperproc
+	int maxFilesPerProc = 0;
+	size_t maxFilesPerProcSize = sizeof( maxFilesPerProc );
+
+	if ( sysctlbyname( "kern.maxfilesperproc", &maxFilesPerProc, &maxFilesPerProcSize, NULL, 0 ) == 0
+		&& maxFilesPerProc > 0 && wanted > (rlim_t)maxFilesPerProc )
+	{
+		wanted = (rlim_t)maxFilesPerProc;
+	}
+#endif
+
+	if ( wanted <= original )
+		return;
+
+	// if the kernel turns down the full amount, keep halving what we ask for so
+	// we still end up with as many descriptors as it is willing to give us
+	for ( rlim_t attempt = wanted; attempt > original; attempt = original + ( attempt - original ) / 2 )
+	{
+		limit.rlim_cur = attempt;
+
+		if ( setrlimit( RLIMIT_NOFILE, &limit ) == 0 )
+			return;
+	}
+
+	fprintf( stderr, "Warning: unable to raise the open file limit above %llu (%s)\n",
+		(unsigned long long)original, strerror( errno ) );
+}
+
 void Sys_PlatformInit( void )
 {
 	const char* term = getenv( "TERM" );
+
+	Sys_RaiseOpenFileLimit();
 
 	signal( SIGHUP, Sys_SigHandler );
 	signal( SIGQUIT, Sys_SigHandler );


### PR DESCRIPTION
macOS ships a soft RLIMIT_NOFILE of 256, which exhausts from pk3 files if using JoF asses(maps, skins etc). 
Raise the soft limit towards the hard limit in Sys_PlatformInit, before Com_Init touches the filesystem.

The hard limit is far higher than the soft one, but Darwin reports it as unlimited while refusing any soft limit above kern.maxfilesperproc, so clamp to that sysctl there and back off by halving if the kernel still turns the request down.

Guard NET_Sleep against a socket landing above FD_SETSIZE as a result: fd_set is a fixed size bitmask on unix, and sockets are created after the filesystem has opened its pk3s, so this was unreachable under the old 256 descriptor cap but is not anymore.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>