### PR TITLE
Scale lightsabers with player model scale

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -6059,7 +6059,17 @@ static void CG_RGBForSaberColor(saber_colors_t color, vec3_t rgb, int cnum, int 
 	}
 }
 
-static void CG_DoSaberLight( saberInfo_t *saber, int cnum, int bnum )//rgb
+static float CG_SaberModelScale( const centity_t *cent )
+{
+	if ( cent && cent->modelScale[0] > 0.0f )
+	{
+		return cent->modelScale[0];
+	}
+
+	return 1.0f;
+}
+
+static void CG_DoSaberLight( saberInfo_t *saber, int cnum, int bnum, float scale )//rgb
 {
 	vec3_t		positions[MAX_BLADES*2], mid={0}, rgbs[MAX_BLADES*2], rgb={0};
 	float		lengths[MAX_BLADES*2]={0}, totallength = 0, numpositions = 0, dist, diameter = 0;
@@ -6084,16 +6094,16 @@ static void CG_DoSaberLight( saberInfo_t *saber, int cnum, int bnum )//rgb
 		{
 			//FIXME: make RGB sabers
 			CG_RGBForSaberColor( saber->blade[i].color, rgbs[i], cnum, bnum );//rgb
-			lengths[i] = saber->blade[i].length;
-			if ( saber->blade[i].length*2.0f > diameter )
+			lengths[i] = saber->blade[i].length * scale;
+			if ( lengths[i]*2.0f > diameter )
 			{
-				diameter = saber->blade[i].length*2.0f;
+				diameter = lengths[i]*2.0f;
 			}
-			totallength += saber->blade[i].length;
-			VectorMA( saber->blade[i].muzzlePoint, saber->blade[i].length, saber->blade[i].muzzleDir, positions[i] );
+			totallength += lengths[i];
+			VectorMA( saber->blade[i].muzzlePoint, lengths[i], saber->blade[i].muzzleDir, positions[i] );
 			if ( !numpositions )
 			{//first blade, store middle of that as midpoint
-				VectorMA( saber->blade[i].muzzlePoint, saber->blade[i].length*0.5, saber->blade[i].muzzleDir, mid );
+				VectorMA( saber->blade[i].muzzlePoint, lengths[i]*0.5f, saber->blade[i].muzzleDir, mid );
 				VectorCopy( rgbs[i], rgb );
 			}
 			numpositions++;
@@ -7358,6 +7368,9 @@ void CG_AddSaberBlade( centity_t *cent, centity_t *scent, refEntity_t *saber, in
 	int i = 0;
 	float trailDur;
 	float saberLen;
+	float saberLengthMax;
+	float saberRadius;
+	float saberScale;
 	float diff;
 	clientInfo_t *client;
 	centity_t *saberEnt;
@@ -7380,7 +7393,10 @@ void CG_AddSaberBlade( centity_t *cent, centity_t *scent, refEntity_t *saber, in
 	}
 
 	saberEnt = &cg_entities[cent->currentState.saberEntityNum];
-	saberLen = client->saber[saberNum].blade[bladeNum].length;
+	saberScale = CG_SaberModelScale( cent );
+	saberLen = client->saber[saberNum].blade[bladeNum].length * saberScale;
+	saberLengthMax = client->saber[saberNum].blade[bladeNum].lengthMax * saberScale;
+	saberRadius = client->saber[saberNum].blade[bladeNum].radius * saberScale;
 
 	if (saberLen <= 0 && !dontDraw)
 	{ //don't bother then.
@@ -7432,7 +7448,7 @@ void CG_AddSaberBlade( centity_t *cent, centity_t *scent, refEntity_t *saber, in
 
 	VectorMA( org_, saberLen, axis_[0], end );
 
-	VectorAdd( end, axis_[0], end );
+	VectorMA( end, saberScale, axis_[0], end );
 
 	if (cent->currentState.eType == ET_NPC)
 	{
@@ -8075,7 +8091,7 @@ JustDoIt:
 		if ( client->saber[saberNum].numBlades < 3
 			&& !(client->saber[saberNum].saberFlags2&SFL2_NO_DLIGHT) )
 		{//hmm, but still add the dlight
-			CG_DoSaberLight( &client->saber[saberNum], cent->currentState.clientNum, saberNum );//rgb
+			CG_DoSaberLight( &client->saber[saberNum], cent->currentState.clientNum, saberNum, saberScale );//rgb
 		}
 		return;
 	}
@@ -8086,13 +8102,13 @@ JustDoIt:
 	//	scolor, renderfx, (qboolean)(saberNum==0&&bladeNum==0) );
 	if (!sfxSabers)
 	{
-		CG_DoSaber( org_, axis_[0], saberLen, client->saber[saberNum].blade[bladeNum].lengthMax, client->saber[saberNum].blade[bladeNum].radius,
+		CG_DoSaber( org_, axis_[0], saberLen, saberLengthMax, saberRadius,
 			scolor, renderfx, (qboolean)(client->saber[saberNum].numBlades < 3 && !(client->saber[saberNum].saberFlags2 & SFL2_NO_DLIGHT)), cent->currentState.clientNum, saberNum );//rgb -- fix casting?
 	}
 	else
 	{
 		CG_DoSFXSaber( fx.mVerts[0].origin, fx.mVerts[1].origin, fx.mVerts[2].origin, fx.mVerts[3].origin,
-			(client->saber[saberNum].blade[bladeNum].lengthMax), (client->saber[saberNum].blade[bladeNum].radius),
+			saberLengthMax, saberRadius,
 			scolor, renderfx, (qboolean)(client->saber[saberNum].numBlades < 3 && !(client->saber[saberNum].saberFlags2 & SFL2_NO_DLIGHT)), cent->currentState.clientNum, saberNum );
 
 		if (cg.time > saberTrail->inAction)
@@ -12822,6 +12838,7 @@ stillDoSaber:
 				}
 
 				saberEnt->currentState.modelGhoul2 = 1;
+				saberEnt->currentState.iModelScale = cent->currentState.iModelScale;
 				CG_ManualEntityRender(saberEnt);
 				saberEnt->bolt3 = 0;
 				saberEnt->currentState.modelGhoul2 = 127;
@@ -12878,7 +12895,7 @@ stillDoSaber:
 					}
 					if ( ci->saber[l].numBlades > 2 )
 					{//add a single glow for the saber based on all the blade colors combined
-						CG_DoSaberLight( &ci->saber[l], cent->currentState.clientNum, l );//rgb
+						CG_DoSaberLight( &ci->saber[l], cent->currentState.clientNum, l, CG_SaberModelScale( cent ) );//rgb
 					}
 
 					l++;
@@ -13082,7 +13099,7 @@ stillDoSaber:
 			}
 			if ( ci->saber[l].numBlades > 2 )
 			{//add a single glow for the saber based on all the blade colors combined
-				CG_DoSaberLight( &ci->saber[l], cent->currentState.clientNum, l );//rgb
+				CG_DoSaberLight( &ci->saber[l], cent->currentState.clientNum, l, CG_SaberModelScale( cent ) );//rgb
 			}
 
 			l++;

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -6061,7 +6061,12 @@ static void CG_RGBForSaberColor(saber_colors_t color, vec3_t rgb, int cnum, int 
 
 static float CG_SaberModelScale( const centity_t *cent )
 {
-	if ( cent && cent->modelScale[0] > 0.0f )
+	if ( !cent || cent->currentState.eType == ET_NPC )
+	{
+		return 1.0f;
+	}
+
+	if ( cent->modelScale[0] > 0.0f )
 	{
 		return cent->modelScale[0];
 	}
@@ -12838,7 +12843,9 @@ stillDoSaber:
 				}
 
 				saberEnt->currentState.modelGhoul2 = 1;
-				saberEnt->currentState.iModelScale = cent->currentState.iModelScale;
+				saberEnt->currentState.iModelScale = cent->currentState.eType == ET_NPC
+					? 0
+					: cent->currentState.iModelScale;
 				CG_ManualEntityRender(saberEnt);
 				saberEnt->bolt3 = 0;
 				saberEnt->currentState.modelGhoul2 = 127;


### PR DESCRIPTION
## What changed

- Scale saber blade length, radius, effects, trails, contact endpoints, and lighting with the owning player's model scale.
- Apply the owner's model scale to thrown saber hilts.
- Preserve the normal `1.0` saber scale when the player has no custom model scale.

## Why

Saber hilts and attachment points followed a scaled player model, but blade geometry and related visual effects still used fixed world-unit dimensions. This made the saber look disproportionate on resized players.

## Impact

Lightsabers now remain visually proportional for model-scaled players, including held, staff/dual, and thrown saber rendering. This is client-side only and does not alter authoritative server damage or reach.

## Validation

- `cmake --build . --config Release --target cgamex86`
- Full x64 Release build via `cmake --build x64 --config Release`
