### PR TITLE
build: fix macOS "Failed loading SDL3 library" by building real SDL2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,9 +245,27 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Install dependencies
+      - name: Build SDL2 from source
+        shell: bash
         run: |
-          brew install sdl2
+          # Homebrew's `sdl2` formula is now an alias for `sdl2-compat`, which is
+          # an SDL2 shim over SDL3. It dlopen()s "libSDL3.dylib" at runtime, so
+          # fixup_bundle cannot see that dependency and never copies it into the
+          # .app -- users without Homebrew's sdl3 then get "Failed loading SDL3
+          # library." Build genuine SDL2 ourselves so the bundle stays complete.
+          SDL2_VERSION=2.32.10
+          curl -L -o SDL2.tar.gz \
+            https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz
+          tar xzf SDL2.tar.gz
+          cmake -S SDL2-${SDL2_VERSION} -B sdl2-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/sdl2-prefix \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TEST=OFF
+          cmake --build sdl2-build -j $(sysctl -n hw.ncpu)
+          cmake --install sdl2-build
+          echo "SDL2DIR=${{ github.workspace }}/sdl2-prefix" >> $GITHUB_ENV
           cmake -E make_directory build
 
       - name: Configure CMake
@@ -649,9 +667,27 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Install dependencies
+      - name: Build SDL2 from source
+        shell: bash
         run: |
-          brew install sdl2
+          # Homebrew's `sdl2` formula is now an alias for `sdl2-compat`, which is
+          # an SDL2 shim over SDL3. It dlopen()s "libSDL3.dylib" at runtime, so
+          # fixup_bundle cannot see that dependency and never copies it into the
+          # .app -- users without Homebrew's sdl3 then get "Failed loading SDL3
+          # library." Build genuine SDL2 ourselves so the bundle stays complete.
+          SDL2_VERSION=2.32.10
+          curl -L -o SDL2.tar.gz \
+            https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz
+          tar xzf SDL2.tar.gz
+          cmake -S SDL2-${SDL2_VERSION} -B sdl2-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/sdl2-prefix \
+            -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+            -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TEST=OFF
+          cmake --build sdl2-build -j $(sysctl -n hw.ncpu)
+          cmake --install sdl2-build
+          echo "SDL2DIR=${{ github.workspace }}/sdl2-prefix" >> $GITHUB_ENV
           cmake -E make_directory build
 
       - name: Configure CMake

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -689,10 +689,21 @@ if(BuildMPEngine)
 	endif(WIN32)
 
 	if(MakeApplicationBundles)
+		# A source-built SDL2 has an @rpath install name rather than an absolute
+		# one, which fixup_bundle cannot resolve on its own. Hand it the library
+		# directory explicitly; harmless when the install name is already absolute.
+		set(MPEngineBundleDirs "")
+		foreach(BundleLib ${SDL2_LIBRARY})
+			if(EXISTS "${BundleLib}")
+				get_filename_component(BundleLibDir "${BundleLib}" DIRECTORY)
+				list(APPEND MPEngineBundleDirs "${BundleLibDir}")
+			endif()
+		endforeach()
+		list(REMOVE_DUPLICATES MPEngineBundleDirs)
 		install(CODE "
 			include(BundleUtilities)
 			set(BU_CHMOD_BUNDLE_ITEMS ON)
-			fixup_bundle(\"${CMAKE_BINARY_DIR}/${MPEngine}.app\" \"\" \"\")
+			fixup_bundle(\"${CMAKE_BINARY_DIR}/${MPEngine}.app\" \"\" \"${MPEngineBundleDirs}\")
 			"
 			COMPONENT Runtime)
 		install(TARGETS ${MPEngine}


### PR DESCRIPTION
Homebrew retired the standalone `sdl2` formula and made `sdl2` an alias for `sdl2-compat`, an SDL2 shim implemented on top of SDL3. Since that switch the macOS jobs have linked the shim instead of SDL2.

The shim has no link-time dependency on SDL3; it dlopen()s "libSDL3.dylib" at runtime. fixup_bundle only walks link-time dependencies, so SDL3 was never copied into the .app. On any Mac without Homebrew's sdl3 the dlopen fails and sdl2-compat raises "Failed loading SDL3 library." Stable releases predate the alias change and bundle a genuine SDL2, which is why only alpha/beta builds were affected. Windows (bundled SDL2) and Linux (libsdl2-dev) were unaffected.

Build a pinned SDL2 2.32.10 from the official source release into a private prefix and point CMake at it via SDL2DIR, in both the beta and master macOS jobs.

A source-built SDL2 carries an @rpath install name rather than the absolute one Homebrew produced, which fixup_bundle cannot resolve on its own, so also hand it the SDL2 library directory.

Pin CMAKE_OSX_DEPLOYMENT_TARGET to 10.9 to match the engine. Without it SDL2 inherits the runner's SDK default (minos 26.0), which dyld enforces and which would lock out every older macOS.

Verified on x86_64 with full engine builds against both libraries: the sdl2-compat build ships SDL2 2.32.70 with three libSDL3 references and hangs on the error dialog, while the patched build ships 2.32.10 with none, initializes cleanly, and has no dependencies outside the bundle. SDL2 was also cross-built for arm64 (correct slice, minos 11.0, no SDL3 references); the arm64 engine link and runtime are unverified.

Co-Authored-By: Claude Opus 5
